### PR TITLE
Batch print with variable substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ You can fight against AI usage or learn to embrace it as a new way of working. I
 - **Per-widget font styles** -- each text widget can have its own font style, scale, frame, and alignment
 - **Multi-printer support** -- automatically detects all connected DYMO printers; select specific printer when multiple are available
 - **Virtual printers** -- configure virtual printers that save labels as PNG images, JSON data, or both (great for testing, archiving, and development)
-- **Save/load labels** -- export label designs to JSON files and load them back, with embedded image data for portability
+- **Batch print** -- print multiple labels with variable content using `:varname:` placeholders, with a table to fill in values per row, configurable copies and pause time, SSE progress streaming, and cancellation support
+- **Save/load labels** -- export label designs to JSON files and load them back, with embedded image data and batch configuration for portability
 - **Print via labelle** -- sends labels to the printer using the labelle Python library over USB
 - **USB power save** -- optionally power off the printer's USB port via uhubctl when the server is idle, and power it back on automatically when the page is opened (opt-in via `USB_POWER_SAVE=true`)
 
@@ -130,8 +131,8 @@ journalctl -u labelle-web -f
 labelle-web/
   client/                   # Vite + React + TypeScript frontend
     src/
-      components/           # React UI components
-      lib/                  # API client, constants
+      components/           # React UI components (BatchPanel, PrintButton, etc.)
+      lib/                  # API client, constants, variable substitution
       state/                # Zustand store
       types/                # TypeScript type definitions
   server/                   # Python/Flask backend
@@ -142,9 +143,10 @@ labelle-web/
     virtual_printer.py      # Virtual printer implementation (saves PNGs/JSON to disk)
     requirements.txt        # Python dependencies
     tests/                  # Backend tests (pytest)
+  docs/                     # Documentation and screenshots
 ```
 
-See [ARCHITECTURE.md](docs/ARCHITECTURE.md) for detailed design documentation.
+See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for detailed design documentation.
 
 ## Configuration
 
@@ -235,6 +237,36 @@ Upload an image for use in image widgets. Accepts `multipart/form-data` with a `
 **Response:** `{ "filename": "uuid.png" }`
 
 The returned filename is used in the `image` widget's `filename` field for subsequent print/preview requests.
+
+### `POST /api/batch-print`
+
+Print multiple labels with variable substitution. Uses Server-Sent Events (SSE) for streaming progress.
+
+**Request body:**
+```json
+{
+  "widgets": [ ... ],
+  "settings": { ... },
+  "rows": [
+    { "name": "Alice", "id": "001" },
+    { "name": "Bob", "id": "002" }
+  ],
+  "copies": 2,
+  "pauseTime": 1.0
+}
+```
+
+Widget text/content fields use `:varname:` placeholders (e.g. `Hello :name:`) which are substituted per row.
+
+**SSE events:** `started` (with jobId, total), `printing`, `printed`, `done`, `cancelled`, `error`
+
+Returns HTTP 409 if another batch job is already running.
+
+### `POST /api/batch-print/cancel`
+
+Cancel a running batch print job. The server finishes the current label then stops.
+
+**Request body:** `{ "jobId": "..." }`
 
 ### `GET /api/power/status`, `POST /api/power/on`, `POST /api/power/off`
 

--- a/README.md
+++ b/README.md
@@ -252,13 +252,18 @@ Print multiple labels with variable substitution. Uses Server-Sent Events (SSE) 
     { "name": "Bob", "id": "002" }
   ],
   "copies": 2,
-  "pauseTime": 1.0
+  "pauseTime": 1.0,
+  "jobId": "optional-client-generated-id"
 }
 ```
 
-Widget text/content fields use `:varname:` placeholders (e.g. `Hello :name:`) which are substituted per row.
+Widget text/content fields use `:varname:` placeholders (e.g. `Hello :name:`) which are substituted per row. Row values must be strings or numbers — `null`, booleans, arrays, and objects are rejected with a 400.
 
-**SSE events:** `started` (with jobId, total), `printing`, `printed`, `done`, `cancelled`, `error`
+`jobId` is optional (8-64 chars of `[a-zA-Z0-9_-]`); the server generates one if omitted. Either way it's echoed back in the `started` event. Supplying it client-side lets you cancel immediately after the POST returns without waiting for `started`.
+
+**Caps (all return 400 if exceeded):** `copies` ≤ 999, `pauseTime` ≤ 60 s, `rows` ≤ 1000, total labels (`rows × copies`) ≤ 10000, and total pause budget (`total × pauseTime`) ≤ 8 hours.
+
+**SSE events:** `started` (with `jobId`, `total`), `printing`, `printed`, `done`, `cancelled`, `error`. The response sets `Cache-Control: no-cache` and `X-Accel-Buffering: no` so events stream through reverse proxies in real time.
 
 Returns HTTP 409 if another batch job is already running.
 
@@ -266,7 +271,9 @@ Returns HTTP 409 if another batch job is already running.
 
 Cancel a running batch print job. The server finishes the current label then stops.
 
-**Request body:** `{ "jobId": "..." }`
+**Request body:** `{ "jobId": "..." }` (required)
+
+**Responses:** 200 `{ status: "ok" }` on success, 400 if `jobId` is missing/empty, 404 if no job with that id is in flight.
 
 ### `GET /api/power/status`, `POST /api/power/on`, `POST /api/power/off`
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,5 @@
 import { SettingsBar } from "./components/SettingsBar";
+import { BatchPanel } from "./components/BatchPanel";
 import { WidgetList } from "./components/WidgetList";
 import { AddWidgetMenu } from "./components/AddWidgetMenu";
 import { SaveLoadButtons } from "./components/SaveLoadButtons";
@@ -40,6 +41,7 @@ export default function App() {
           <div className="pt-4">
             <SaveLoadButtons />
           </div>
+          <BatchPanel />
           <SettingsBar />
         </div>
       </div>

--- a/client/src/components/BatchPanel.tsx
+++ b/client/src/components/BatchPanel.tsx
@@ -1,0 +1,151 @@
+import { useMemo } from "react";
+import { useLabelStore } from "../state/useLabelStore";
+import { detectVariables } from "../lib/variables";
+
+export function BatchPanel() {
+  const widgets = useLabelStore((s) => s.widgets);
+  const batch = useLabelStore((s) => s.batch);
+  const updateBatch = useLabelStore((s) => s.updateBatch);
+  const setBatchRow = useLabelStore((s) => s.setBatchRow);
+  const addBatchRow = useLabelStore((s) => s.addBatchRow);
+  const removeBatchRow = useLabelStore((s) => s.removeBatchRow);
+
+  const variables = useMemo(() => detectVariables(widgets), [widgets]);
+
+  return (
+    <details
+      className="bg-white rounded-lg shadow"
+      open={batch.enabled}
+      onToggle={(e) =>
+        updateBatch({ enabled: (e.target as HTMLDetailsElement).open })
+      }
+    >
+      <summary className="cursor-pointer select-none p-3 text-sm font-medium text-gray-700">
+        Batch Print
+      </summary>
+      <div className="p-3 pt-0 space-y-3 text-sm">
+        <div className="flex flex-wrap gap-4">
+          <label className="flex items-center gap-1.5">
+            <span className="text-gray-600">Copies</span>
+            <input
+              type="number"
+              className="input w-20"
+              min={1}
+              max={999}
+              value={batch.copies}
+              onChange={(e) =>
+                updateBatch({ copies: Math.max(1, Number(e.target.value)) })
+              }
+            />
+          </label>
+          <label className="flex items-center gap-1.5">
+            <span className="text-gray-600">Pause (s)</span>
+            <input
+              type="number"
+              className="input w-20"
+              min={0}
+              max={60}
+              step={0.5}
+              value={batch.pauseTime}
+              onChange={(e) =>
+                updateBatch({
+                  pauseTime: Math.max(0, Number(e.target.value)),
+                })
+              }
+            />
+          </label>
+        </div>
+
+        {variables.length === 0 ? (
+          <p className="text-gray-400 text-xs">
+            Use <code className="bg-gray-100 px-1 rounded">:varname:</code> in
+            widget text to define variables.
+          </p>
+        ) : (
+          <>
+            <div className="overflow-x-auto">
+              <table className="w-full border-collapse text-xs">
+                <thead>
+                  <tr className="bg-gray-50">
+                    <th className="border border-gray-200 px-2 py-1 text-left w-8">
+                      #
+                    </th>
+                    {variables.map((v) => (
+                      <th
+                        key={v}
+                        className="border border-gray-200 px-2 py-1 text-left"
+                      >
+                        {v}
+                      </th>
+                    ))}
+                    <th className="border border-gray-200 px-2 py-1 w-8" />
+                  </tr>
+                </thead>
+                <tbody>
+                  {batch.rows.map((row, rowIdx) => (
+                    <tr
+                      key={rowIdx}
+                      className={`cursor-pointer ${
+                        batch.selectedRowIndex === rowIdx
+                          ? "bg-blue-50"
+                          : "hover:bg-gray-50"
+                      }`}
+                      onClick={() =>
+                        updateBatch({
+                          selectedRowIndex:
+                            batch.selectedRowIndex === rowIdx
+                              ? null
+                              : rowIdx,
+                        })
+                      }
+                    >
+                      <td className="border border-gray-200 px-2 py-1 text-gray-400">
+                        {rowIdx + 1}
+                      </td>
+                      {variables.map((v) => (
+                        <td
+                          key={v}
+                          className="border border-gray-200 px-1 py-0.5"
+                        >
+                          <input
+                            type="text"
+                            className="w-full bg-transparent outline-none px-1 py-0.5"
+                            value={row[v] ?? ""}
+                            onClick={(e) => e.stopPropagation()}
+                            onChange={(e) =>
+                              setBatchRow(rowIdx, v, e.target.value)
+                            }
+                          />
+                        </td>
+                      ))}
+                      <td className="border border-gray-200 px-1 py-0.5 text-center">
+                        {batch.rows.length > 1 && (
+                          <button
+                            className="text-red-400 hover:text-red-600"
+                            title="Remove row"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              removeBatchRow(rowIdx);
+                            }}
+                          >
+                            x
+                          </button>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <button
+              className="text-blue-600 hover:text-blue-800 text-xs"
+              onClick={addBatchRow}
+            >
+              + Add Row
+            </button>
+          </>
+        )}
+      </div>
+    </details>
+  );
+}

--- a/client/src/components/BatchPanel.tsx
+++ b/client/src/components/BatchPanel.tsx
@@ -199,9 +199,15 @@ export function BatchPanel() {
                               }
                               title={
                                 isPreviewed
-                                  ? "Stop previewing this row"
-                                  : "Preview this row"
+                                  ? `Stop previewing row ${rowIdx + 1}`
+                                  : `Preview row ${rowIdx + 1}`
                               }
+                              aria-label={
+                                isPreviewed
+                                  ? `Stop previewing row ${rowIdx + 1}`
+                                  : `Preview row ${rowIdx + 1}`
+                              }
+                              aria-pressed={isPreviewed}
                               onClick={() =>
                                 updateBatch({
                                   selectedRowIndex: isPreviewed ? null : rowIdx,
@@ -213,10 +219,11 @@ export function BatchPanel() {
                             {batch.rows.length > 1 ? (
                               <button
                                 className="text-red-400 hover:text-red-600"
-                                title="Remove row"
+                                title={`Remove row ${rowIdx + 1}`}
+                                aria-label={`Remove row ${rowIdx + 1}`}
                                 onClick={() => removeBatchRow(rowIdx)}
                               >
-                                x
+                                <span aria-hidden="true">x</span>
                               </button>
                             ) : (
                               <span className="w-3" />

--- a/client/src/components/BatchPanel.tsx
+++ b/client/src/components/BatchPanel.tsx
@@ -37,16 +37,15 @@ export function BatchPanel() {
   const updateWidget = useLabelStore((s) => s.updateWidget);
 
   const variables = useMemo(() => detectVariables(widgets), [widgets]);
+  const hasVariables = variables.length > 0;
 
-  // <details> open state is decoupled from batch.enabled — opening the
-  // panel to view its contents should not flip the Print button to batch
-  // mode. We do auto-open when batch.enabled goes true (initial mount, or
-  // a label file load that turns batch on), but the user can collapse it
-  // afterwards without disabling batch mode.
-  const [open, setOpen] = useState(batch.enabled);
+  // <details> auto-opens when variables appear (initial mount or a later
+  // edit / file load), and stays open while they exist. The user can still
+  // collapse it manually for a quick view of the rest of the editor.
+  const [open, setOpen] = useState(hasVariables);
   useEffect(() => {
-    if (batch.enabled) setOpen(true);
-  }, [batch.enabled]);
+    if (hasVariables) setOpen(true);
+  }, [hasVariables]);
 
   // Local string state for number inputs so the user can clear and retype
   // without the value snapping back to a clamped minimum mid-edit.
@@ -99,15 +98,6 @@ export function BatchPanel() {
         Batch Print
       </summary>
       <div className="p-3 pt-0 space-y-3 text-sm">
-        <label className="flex items-center gap-2">
-          <input
-            type="checkbox"
-            checked={batch.enabled}
-            onChange={(e) => updateBatch({ enabled: e.target.checked })}
-          />
-          <span className="text-gray-700">Enable batch printing</span>
-        </label>
-
         {variables.length === 0 ? (
           <div className="space-y-2">
             <p className="text-gray-400 text-xs">

--- a/client/src/components/BatchPanel.tsx
+++ b/client/src/components/BatchPanel.tsx
@@ -33,10 +33,15 @@ export function BatchPanel() {
 
   const variables = useMemo(() => detectVariables(widgets), [widgets]);
 
-  // <details> open state is decoupled from batch.enabled. Opening the panel
-  // to view its contents should not flip the Print button to batch mode.
-  // Default-open when batch is already enabled (e.g., loaded from file).
+  // <details> open state is decoupled from batch.enabled — opening the
+  // panel to view its contents should not flip the Print button to batch
+  // mode. We do auto-open when batch.enabled goes true (initial mount, or
+  // a label file load that turns batch on), but the user can collapse it
+  // afterwards without disabling batch mode.
   const [open, setOpen] = useState(batch.enabled);
+  useEffect(() => {
+    if (batch.enabled) setOpen(true);
+  }, [batch.enabled]);
 
   // Local string state for number inputs so the user can clear and retype
   // without the value snapping back to a clamped minimum mid-edit.

--- a/client/src/components/BatchPanel.tsx
+++ b/client/src/components/BatchPanel.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
 import { useLabelStore } from "../state/useLabelStore";
 import { detectVariables } from "../lib/variables";
-import { MAX_BATCH_COPIES, MAX_BATCH_PAUSE_SECONDS } from "../lib/constants";
+import {
+  MAX_BATCH_COPIES,
+  MAX_BATCH_PAUSE_SECONDS,
+  MAX_BATCH_ROWS,
+} from "../lib/constants";
 
 function EyeIcon({ active }: { active: boolean }) {
   return (
@@ -236,10 +240,16 @@ export function BatchPanel() {
                 </tbody>
               </table>
             </div>
-            <div className="flex gap-3">
+            <div className="flex gap-3 items-center">
               <button
-                className="text-blue-600 hover:text-blue-800 text-xs"
+                className="text-blue-600 hover:text-blue-800 disabled:text-gray-400 disabled:cursor-not-allowed text-xs"
                 onClick={addBatchRow}
+                disabled={batch.rows.length >= MAX_BATCH_ROWS}
+                title={
+                  batch.rows.length >= MAX_BATCH_ROWS
+                    ? `Maximum ${MAX_BATCH_ROWS} rows`
+                    : undefined
+                }
               >
                 + Add Row
               </button>

--- a/client/src/components/BatchPanel.tsx
+++ b/client/src/components/BatchPanel.tsx
@@ -2,6 +2,25 @@ import { useMemo } from "react";
 import { useLabelStore } from "../state/useLabelStore";
 import { detectVariables } from "../lib/variables";
 
+function EyeIcon({ active }: { active: boolean }) {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill={active ? "currentColor" : "none"}
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7S2 12 2 12z" />
+      <circle cx="12" cy="12" r="3" fill={active ? "white" : "none"} />
+    </svg>
+  );
+}
+
 export function BatchPanel() {
   const widgets = useLabelStore((s) => s.widgets);
   const batch = useLabelStore((s) => s.batch);
@@ -78,62 +97,72 @@ export function BatchPanel() {
                         {v}
                       </th>
                     ))}
-                    <th className="border border-gray-200 px-2 py-1 w-8" />
+                    <th className="border border-gray-200 px-2 py-1 w-16" />
                   </tr>
                 </thead>
                 <tbody>
-                  {batch.rows.map((row, rowIdx) => (
-                    <tr
-                      key={rowIdx}
-                      className={`cursor-pointer ${
-                        batch.selectedRowIndex === rowIdx
-                          ? "bg-blue-50"
-                          : "hover:bg-gray-50"
-                      }`}
-                      onClick={() =>
-                        updateBatch({
-                          selectedRowIndex:
-                            batch.selectedRowIndex === rowIdx
-                              ? null
-                              : rowIdx,
-                        })
-                      }
-                    >
-                      <td className="border border-gray-200 px-2 py-1 text-gray-400">
-                        {rowIdx + 1}
-                      </td>
-                      {variables.map((v) => (
-                        <td
-                          key={v}
-                          className="border border-gray-200 px-1 py-0.5"
-                        >
-                          <input
-                            type="text"
-                            className="w-full bg-transparent outline-none px-1 py-0.5"
-                            value={row[v] ?? ""}
-                            onClick={(e) => e.stopPropagation()}
-                            onChange={(e) =>
-                              setBatchRow(rowIdx, v, e.target.value)
-                            }
-                          />
+                  {batch.rows.map((row, rowIdx) => {
+                    const isPreviewed = batch.selectedRowIndex === rowIdx;
+                    return (
+                      <tr
+                        key={rowIdx}
+                        className={isPreviewed ? "bg-blue-50" : ""}
+                      >
+                        <td className="border border-gray-200 px-2 py-1 text-gray-400">
+                          {rowIdx + 1}
                         </td>
-                      ))}
-                      <td className="border border-gray-200 px-1 py-0.5 text-center">
-                        {batch.rows.length > 1 && (
-                          <button
-                            className="text-red-400 hover:text-red-600"
-                            title="Remove row"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              removeBatchRow(rowIdx);
-                            }}
+                        {variables.map((v) => (
+                          <td
+                            key={v}
+                            className="border border-gray-200 px-1 py-0.5"
                           >
-                            x
-                          </button>
-                        )}
-                      </td>
-                    </tr>
-                  ))}
+                            <input
+                              type="text"
+                              className="w-full bg-transparent outline-none px-1 py-0.5"
+                              value={row[v] ?? ""}
+                              onChange={(e) =>
+                                setBatchRow(rowIdx, v, e.target.value)
+                              }
+                            />
+                          </td>
+                        ))}
+                        <td className="border border-gray-200 px-1 py-0.5">
+                          <div className="flex items-center justify-center gap-2">
+                            <button
+                              className={
+                                isPreviewed
+                                  ? "text-blue-600"
+                                  : "text-gray-400 hover:text-blue-600"
+                              }
+                              title={
+                                isPreviewed
+                                  ? "Stop previewing this row"
+                                  : "Preview this row"
+                              }
+                              onClick={() =>
+                                updateBatch({
+                                  selectedRowIndex: isPreviewed ? null : rowIdx,
+                                })
+                              }
+                            >
+                              <EyeIcon active={isPreviewed} />
+                            </button>
+                            {batch.rows.length > 1 ? (
+                              <button
+                                className="text-red-400 hover:text-red-600"
+                                title="Remove row"
+                                onClick={() => removeBatchRow(rowIdx)}
+                              >
+                                x
+                              </button>
+                            ) : (
+                              <span className="w-3" />
+                            )}
+                          </div>
+                        </td>
+                      </tr>
+                    );
+                  })}
                 </tbody>
               </table>
             </div>

--- a/client/src/components/BatchPanel.tsx
+++ b/client/src/components/BatchPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useLabelStore } from "../state/useLabelStore";
 import { detectVariables } from "../lib/variables";
 
@@ -33,6 +33,29 @@ export function BatchPanel() {
 
   const variables = useMemo(() => detectVariables(widgets), [widgets]);
 
+  // <details> open state is decoupled from batch.enabled. Opening the panel
+  // to view its contents should not flip the Print button to batch mode.
+  // Default-open when batch is already enabled (e.g., loaded from file).
+  const [open, setOpen] = useState(batch.enabled);
+
+  // Local string state for number inputs so the user can clear and retype
+  // without the value snapping back to a clamped minimum mid-edit.
+  const [copiesInput, setCopiesInput] = useState(String(batch.copies));
+  const [pauseInput, setPauseInput] = useState(String(batch.pauseTime));
+  useEffect(() => setCopiesInput(String(batch.copies)), [batch.copies]);
+  useEffect(() => setPauseInput(String(batch.pauseTime)), [batch.pauseTime]);
+
+  const commitCopies = () => {
+    const n = Math.max(1, Math.min(999, Number(copiesInput) || 1));
+    updateBatch({ copies: n });
+    setCopiesInput(String(n));
+  };
+  const commitPause = () => {
+    const n = Math.max(0, Math.min(60, Number(pauseInput) || 0));
+    updateBatch({ pauseTime: n });
+    setPauseInput(String(n));
+  };
+
   const handleAddVariable = () => {
     const state = useLabelStore.getState();
     const existing = new Set(detectVariables(state.widgets));
@@ -55,15 +78,21 @@ export function BatchPanel() {
   return (
     <details
       className="bg-white rounded-lg shadow"
-      open={batch.enabled}
-      onToggle={(e) =>
-        updateBatch({ enabled: (e.target as HTMLDetailsElement).open })
-      }
+      open={open}
+      onToggle={(e) => setOpen((e.target as HTMLDetailsElement).open)}
     >
       <summary className="cursor-pointer select-none p-3 text-sm font-medium text-gray-700">
         Batch Print
       </summary>
       <div className="p-3 pt-0 space-y-3 text-sm">
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={batch.enabled}
+            onChange={(e) => updateBatch({ enabled: e.target.checked })}
+          />
+          <span className="text-gray-700">Enable batch printing</span>
+        </label>
         <div className="flex flex-wrap gap-4">
           <label className="flex items-center gap-1.5">
             <span className="text-gray-600">Copies</span>
@@ -72,10 +101,9 @@ export function BatchPanel() {
               className="input w-20"
               min={1}
               max={999}
-              value={batch.copies}
-              onChange={(e) =>
-                updateBatch({ copies: Math.max(1, Number(e.target.value)) })
-              }
+              value={copiesInput}
+              onChange={(e) => setCopiesInput(e.target.value)}
+              onBlur={commitCopies}
             />
           </label>
           <label className="flex items-center gap-1.5">
@@ -86,12 +114,9 @@ export function BatchPanel() {
               min={0}
               max={60}
               step={0.5}
-              value={batch.pauseTime}
-              onChange={(e) =>
-                updateBatch({
-                  pauseTime: Math.max(0, Number(e.target.value)),
-                })
-              }
+              value={pauseInput}
+              onChange={(e) => setPauseInput(e.target.value)}
+              onBlur={commitPause}
             />
           </label>
         </div>

--- a/client/src/components/BatchPanel.tsx
+++ b/client/src/components/BatchPanel.tsx
@@ -107,33 +107,6 @@ export function BatchPanel() {
           />
           <span className="text-gray-700">Enable batch printing</span>
         </label>
-        <div className="flex flex-wrap gap-4">
-          <label className="flex items-center gap-1.5">
-            <span className="text-gray-600">Copies</span>
-            <input
-              type="number"
-              className="input w-20"
-              min={1}
-              max={MAX_BATCH_COPIES}
-              value={copiesInput}
-              onChange={(e) => setCopiesInput(e.target.value)}
-              onBlur={commitCopies}
-            />
-          </label>
-          <label className="flex items-center gap-1.5">
-            <span className="text-gray-600">Pause (s)</span>
-            <input
-              type="number"
-              className="input w-20"
-              min={0}
-              max={MAX_BATCH_PAUSE_SECONDS}
-              step={0.5}
-              value={pauseInput}
-              onChange={(e) => setPauseInput(e.target.value)}
-              onBlur={commitPause}
-            />
-          </label>
-        </div>
 
         {variables.length === 0 ? (
           <div className="space-y-2">
@@ -262,6 +235,34 @@ export function BatchPanel() {
             </div>
           </>
         )}
+
+        <div className="flex flex-wrap gap-4 pt-1 border-t border-gray-100">
+          <label className="flex items-center gap-1.5">
+            <span className="text-gray-600">Copies</span>
+            <input
+              type="number"
+              className="input w-20"
+              min={1}
+              max={MAX_BATCH_COPIES}
+              value={copiesInput}
+              onChange={(e) => setCopiesInput(e.target.value)}
+              onBlur={commitCopies}
+            />
+          </label>
+          <label className="flex items-center gap-1.5">
+            <span className="text-gray-600">Pause (s)</span>
+            <input
+              type="number"
+              className="input w-20"
+              min={0}
+              max={MAX_BATCH_PAUSE_SECONDS}
+              step={0.5}
+              value={pauseInput}
+              onChange={(e) => setPauseInput(e.target.value)}
+              onBlur={commitPause}
+            />
+          </label>
+        </div>
       </div>
     </details>
   );

--- a/client/src/components/BatchPanel.tsx
+++ b/client/src/components/BatchPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useLabelStore } from "../state/useLabelStore";
 import { detectVariables } from "../lib/variables";
+import { MAX_BATCH_COPIES, MAX_BATCH_PAUSE_SECONDS } from "../lib/constants";
 
 function EyeIcon({ active }: { active: boolean }) {
   return (
@@ -51,12 +52,18 @@ export function BatchPanel() {
   useEffect(() => setPauseInput(String(batch.pauseTime)), [batch.pauseTime]);
 
   const commitCopies = () => {
-    const n = Math.max(1, Math.min(999, Number(copiesInput) || 1));
+    const parsed = Number(copiesInput);
+    const n = Number.isFinite(parsed)
+      ? Math.max(1, Math.min(MAX_BATCH_COPIES, parsed))
+      : 1;
     updateBatch({ copies: n });
     setCopiesInput(String(n));
   };
   const commitPause = () => {
-    const n = Math.max(0, Math.min(60, Number(pauseInput) || 0));
+    const parsed = Number(pauseInput);
+    const n = Number.isFinite(parsed)
+      ? Math.max(0, Math.min(MAX_BATCH_PAUSE_SECONDS, parsed))
+      : 0;
     updateBatch({ pauseTime: n });
     setPauseInput(String(n));
   };
@@ -103,7 +110,7 @@ export function BatchPanel() {
               type="number"
               className="input w-20"
               min={1}
-              max={999}
+              max={MAX_BATCH_COPIES}
               value={copiesInput}
               onChange={(e) => setCopiesInput(e.target.value)}
               onBlur={commitCopies}
@@ -115,7 +122,7 @@ export function BatchPanel() {
               type="number"
               className="input w-20"
               min={0}
-              max={60}
+              max={MAX_BATCH_PAUSE_SECONDS}
               step={0.5}
               value={pauseInput}
               onChange={(e) => setPauseInput(e.target.value)}

--- a/client/src/components/BatchPanel.tsx
+++ b/client/src/components/BatchPanel.tsx
@@ -168,7 +168,7 @@ export function BatchPanel() {
                     const isPreviewed = batch.selectedRowIndex === rowIdx;
                     return (
                       <tr
-                        key={rowIdx}
+                        key={row.id}
                         className={isPreviewed ? "bg-blue-50" : ""}
                       >
                         <td className="border border-gray-200 px-2 py-1 text-gray-400">
@@ -182,7 +182,7 @@ export function BatchPanel() {
                             <input
                               type="text"
                               className="w-full bg-transparent outline-none px-1 py-0.5"
-                              value={row[v] ?? ""}
+                              value={row.values[v] ?? ""}
                               onChange={(e) =>
                                 setBatchRow(rowIdx, v, e.target.value)
                               }

--- a/client/src/components/BatchPanel.tsx
+++ b/client/src/components/BatchPanel.tsx
@@ -28,8 +28,29 @@ export function BatchPanel() {
   const setBatchRow = useLabelStore((s) => s.setBatchRow);
   const addBatchRow = useLabelStore((s) => s.addBatchRow);
   const removeBatchRow = useLabelStore((s) => s.removeBatchRow);
+  const addTextWidget = useLabelStore((s) => s.addTextWidget);
+  const updateWidget = useLabelStore((s) => s.updateWidget);
 
   const variables = useMemo(() => detectVariables(widgets), [widgets]);
+
+  const handleAddVariable = () => {
+    const state = useLabelStore.getState();
+    const existing = new Set(detectVariables(state.widgets));
+    let i = 1;
+    while (existing.has(`var${i}`)) i++;
+    const placeholder = `:var${i}:`;
+
+    const firstText = state.widgets.find((w) => w.type === "text");
+    if (firstText) {
+      const sep = firstText.text.length > 0 ? " " : "";
+      updateWidget(firstText.id, { text: `${firstText.text}${sep}${placeholder}` });
+    } else {
+      addTextWidget();
+      const after = useLabelStore.getState().widgets;
+      const added = after[after.length - 1];
+      if (added) updateWidget(added.id, { text: placeholder });
+    }
+  };
 
   return (
     <details
@@ -76,10 +97,17 @@ export function BatchPanel() {
         </div>
 
         {variables.length === 0 ? (
-          <p className="text-gray-400 text-xs">
-            Use <code className="bg-gray-100 px-1 rounded">:varname:</code> in
-            widget text to define variables.
-          </p>
+          <div className="space-y-2">
+            <p className="text-gray-400 text-xs">
+              Add a variable, or type <code className="bg-gray-100 px-1 rounded">:varname:</code> into a widget.
+            </p>
+            <button
+              className="text-blue-600 hover:text-blue-800 text-xs"
+              onClick={handleAddVariable}
+            >
+              + Add Variable
+            </button>
+          </div>
         ) : (
           <>
             <div className="overflow-x-auto">
@@ -166,12 +194,20 @@ export function BatchPanel() {
                 </tbody>
               </table>
             </div>
-            <button
-              className="text-blue-600 hover:text-blue-800 text-xs"
-              onClick={addBatchRow}
-            >
-              + Add Row
-            </button>
+            <div className="flex gap-3">
+              <button
+                className="text-blue-600 hover:text-blue-800 text-xs"
+                onClick={addBatchRow}
+              >
+                + Add Row
+              </button>
+              <button
+                className="text-blue-600 hover:text-blue-800 text-xs"
+                onClick={handleAddVariable}
+              >
+                + Add Variable
+              </button>
+            </div>
           </>
         )}
       </div>

--- a/client/src/components/BatchPanel.tsx
+++ b/client/src/components/BatchPanel.tsx
@@ -68,10 +68,8 @@ export function BatchPanel() {
       const sep = firstText.text.length > 0 ? " " : "";
       updateWidget(firstText.id, { text: `${firstText.text}${sep}${placeholder}` });
     } else {
-      addTextWidget();
-      const after = useLabelStore.getState().widgets;
-      const added = after[after.length - 1];
-      if (added) updateWidget(added.id, { text: placeholder });
+      const newId = addTextWidget();
+      updateWidget(newId, { text: placeholder });
     }
   };
 

--- a/client/src/components/LabelPreview.tsx
+++ b/client/src/components/LabelPreview.tsx
@@ -12,12 +12,12 @@ export function LabelPreview() {
   const prevUrlRef = useRef<string | null>(null);
 
   const previewWidgets = useMemo(() => {
-    if (batch.enabled && batch.selectedRowIndex !== null) {
+    if (batch.selectedRowIndex !== null) {
       const row = batch.rows[batch.selectedRowIndex];
       if (row) return substituteWidgets(widgets, row.values);
     }
     return widgets;
-  }, [widgets, batch.enabled, batch.selectedRowIndex, batch.rows]);
+  }, [widgets, batch.selectedRowIndex, batch.rows]);
 
   useEffect(() => {
     const hasContent = previewWidgets.some((w) => {

--- a/client/src/components/LabelPreview.tsx
+++ b/client/src/components/LabelPreview.tsx
@@ -14,7 +14,7 @@ export function LabelPreview() {
   const previewWidgets = useMemo(() => {
     if (batch.enabled && batch.selectedRowIndex !== null) {
       const row = batch.rows[batch.selectedRowIndex];
-      if (row) return substituteWidgets(widgets, row);
+      if (row) return substituteWidgets(widgets, row.values);
     }
     return widgets;
   }, [widgets, batch.enabled, batch.selectedRowIndex, batch.rows]);

--- a/client/src/components/PrintButton.tsx
+++ b/client/src/components/PrintButton.tsx
@@ -1,14 +1,21 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { useLabelStore } from "../state/useLabelStore";
-import { printLabel } from "../lib/api";
+import { printLabel, batchPrint, cancelBatchPrint } from "../lib/api";
+import type { BatchEvent } from "../lib/api";
 
 export function PrintButton() {
   const widgets = useLabelStore((s) => s.widgets);
   const settings = useLabelStore((s) => s.settings);
+  const batch = useLabelStore((s) => s.batch);
   const [status, setStatus] = useState<{
     type: "idle" | "loading" | "success" | "error";
     message?: string;
   }>({ type: "idle" });
+  const jobIdRef = useRef<string | null>(null);
+
+  const totalLabels = batch.enabled
+    ? batch.rows.length * batch.copies
+    : 1;
 
   const handlePrint = async () => {
     if (widgets.length === 0) {
@@ -17,36 +24,99 @@ export function PrintButton() {
     }
 
     setStatus({ type: "loading" });
+
     try {
-      const result = await printLabel(widgets, settings);
-      if (result.status === "success") {
-        setStatus({ type: "success", message: result.message });
+      if (batch.enabled) {
+        await batchPrint(
+          widgets,
+          settings,
+          batch.rows,
+          batch.copies,
+          batch.pauseTime,
+          (event: BatchEvent) => {
+            switch (event.event) {
+              case "started":
+                jobIdRef.current = event.jobId ?? null;
+                break;
+              case "printing":
+                setStatus({
+                  type: "loading",
+                  message: `Printing ${(event.index ?? 0) + 1}/${event.total}...`,
+                });
+                break;
+              case "done":
+                setStatus({
+                  type: "success",
+                  message: `Printed ${event.total} labels.`,
+                });
+                break;
+              case "cancelled":
+                setStatus({
+                  type: "success",
+                  message: `Cancelled after ${event.printed} labels.`,
+                });
+                break;
+              case "error":
+                setStatus({
+                  type: "error",
+                  message: event.message ?? "Print error",
+                });
+                break;
+            }
+          },
+        );
       } else {
-        setStatus({ type: "error", message: result.message });
+        const result = await printLabel(widgets, settings);
+        if (result.status === "success") {
+          setStatus({ type: "success", message: result.message });
+        } else {
+          setStatus({ type: "error", message: result.message });
+        }
       }
     } catch (err) {
       setStatus({
         type: "error",
         message: err instanceof Error ? err.message : "Network error",
       });
+    } finally {
+      jobIdRef.current = null;
     }
 
-    // Clear success after 3 seconds
     setTimeout(() => {
       setStatus((s) => (s.type === "success" ? { type: "idle" } : s));
     }, 3000);
   };
 
+  const handleCancel = () => {
+    if (jobIdRef.current) {
+      cancelBatchPrint(jobIdRef.current);
+    }
+  };
+
   return (
     <div>
-      <button
-        className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 text-white py-3 rounded-lg font-semibold transition-colors"
-        onClick={handlePrint}
-        disabled={status.type === "loading"}
-      >
-        {status.type === "loading" ? "Printing..." : "Print Label"}
-      </button>
-      {status.message && (
+      <div className="flex gap-2">
+        <button
+          className="flex-1 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 text-white py-3 rounded-lg font-semibold transition-colors"
+          onClick={handlePrint}
+          disabled={status.type === "loading"}
+        >
+          {status.type === "loading"
+            ? status.message ?? "Printing..."
+            : batch.enabled
+              ? `Batch Print (${totalLabels} labels)`
+              : "Print Label"}
+        </button>
+        {status.type === "loading" && batch.enabled && (
+          <button
+            className="bg-red-500 hover:bg-red-600 text-white px-4 py-3 rounded-lg font-semibold transition-colors"
+            onClick={handleCancel}
+          >
+            Cancel
+          </button>
+        )}
+      </div>
+      {status.message && status.type !== "loading" && (
         <p
           className={`text-sm mt-2 text-center ${
             status.type === "success" ? "text-green-600" : "text-red-600"

--- a/client/src/components/PrintButton.tsx
+++ b/client/src/components/PrintButton.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import { useLabelStore } from "../state/useLabelStore";
 import { printLabel, batchPrint, cancelBatchPrint } from "../lib/api";
 import type { BatchEvent } from "../lib/api";
@@ -12,6 +12,13 @@ export function PrintButton() {
     message?: string;
   }>({ type: "idle" });
   const jobIdRef = useRef<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  // On unmount, abort any in-flight batch stream so onProgress doesn't fire
+  // setStatus on a torn-down component.
+  useEffect(() => {
+    return () => abortRef.current?.abort();
+  }, []);
 
   const totalLabels = batch.enabled
     ? batch.rows.length * batch.copies
@@ -27,6 +34,8 @@ export function PrintButton() {
 
     try {
       if (batch.enabled) {
+        const controller = new AbortController();
+        abortRef.current = controller;
         await batchPrint(
           widgets,
           settings,
@@ -37,6 +46,10 @@ export function PrintButton() {
             switch (event.event) {
               case "started":
                 jobIdRef.current = event.jobId ?? null;
+                setStatus({
+                  type: "loading",
+                  message: `Starting batch of ${event.total}...`,
+                });
                 break;
               case "printing":
                 setStatus({
@@ -64,6 +77,7 @@ export function PrintButton() {
                 break;
             }
           },
+          controller.signal,
         );
       } else {
         const result = await printLabel(widgets, settings);
@@ -74,12 +88,15 @@ export function PrintButton() {
         }
       }
     } catch (err) {
+      // AbortError on unmount: don't surface, the component is gone anyway.
+      if (err instanceof DOMException && err.name === "AbortError") return;
       setStatus({
         type: "error",
         message: err instanceof Error ? err.message : "Network error",
       });
     } finally {
       jobIdRef.current = null;
+      abortRef.current = null;
     }
 
     setTimeout(() => {

--- a/client/src/components/PrintButton.tsx
+++ b/client/src/components/PrintButton.tsx
@@ -1,13 +1,18 @@
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useMemo } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { useLabelStore } from "../state/useLabelStore";
 import { printLabel, batchPrint, cancelBatchPrint } from "../lib/api";
 import type { BatchEvent } from "../lib/api";
+import { detectVariables } from "../lib/variables";
 
 export function PrintButton() {
   const widgets = useLabelStore((s) => s.widgets);
   const settings = useLabelStore((s) => s.settings);
   const batch = useLabelStore((s) => s.batch);
+  const hasVariables = useMemo(
+    () => detectVariables(widgets).length > 0,
+    [widgets],
+  );
   const [status, setStatus] = useState<{
     type: "idle" | "loading" | "success" | "error";
     message?: string;
@@ -30,7 +35,7 @@ export function PrintButton() {
     };
   }, []);
 
-  const totalLabels = batch.enabled
+  const totalLabels = hasVariables
     ? batch.rows.length * batch.copies
     : 1;
 
@@ -43,7 +48,7 @@ export function PrintButton() {
     setStatus({ type: "loading" });
 
     try {
-      if (batch.enabled) {
+      if (hasVariables) {
         const controller = new AbortController();
         abortRef.current = controller;
         // Generate the jobId client-side so the unmount cleanup can cancel
@@ -136,16 +141,16 @@ export function PrintButton() {
           onClick={handlePrint}
           disabled={
             status.type === "loading" ||
-            (batch.enabled && totalLabels === 0)
+            (hasVariables && totalLabels === 0)
           }
         >
           {status.type === "loading"
             ? status.message ?? "Printing..."
-            : batch.enabled
+            : hasVariables
               ? `Batch Print (${totalLabels} labels)`
               : "Print Label"}
         </button>
-        {status.type === "loading" && batch.enabled && (
+        {status.type === "loading" && hasVariables && (
           <button
             className="bg-red-500 hover:bg-red-600 text-white px-4 py-3 rounded-lg font-semibold transition-colors"
             onClick={handleCancel}

--- a/client/src/components/PrintButton.tsx
+++ b/client/src/components/PrintButton.tsx
@@ -101,7 +101,10 @@ export function PrintButton() {
         <button
           className="flex-1 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 text-white py-3 rounded-lg font-semibold transition-colors"
           onClick={handlePrint}
-          disabled={status.type === "loading"}
+          disabled={
+            status.type === "loading" ||
+            (batch.enabled && totalLabels === 0)
+          }
         >
           {status.type === "loading"
             ? status.message ?? "Printing..."

--- a/client/src/components/PrintButton.tsx
+++ b/client/src/components/PrintButton.tsx
@@ -39,7 +39,7 @@ export function PrintButton() {
         await batchPrint(
           widgets,
           settings,
-          batch.rows,
+          batch.rows.map((r) => r.values),
           batch.copies,
           batch.pauseTime,
           (event: BatchEvent) => {

--- a/client/src/components/PrintButton.tsx
+++ b/client/src/components/PrintButton.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from "react";
+import { v4 as uuidv4 } from "uuid";
 import { useLabelStore } from "../state/useLabelStore";
 import { printLabel, batchPrint, cancelBatchPrint } from "../lib/api";
 import type { BatchEvent } from "../lib/api";
@@ -45,16 +46,22 @@ export function PrintButton() {
       if (batch.enabled) {
         const controller = new AbortController();
         abortRef.current = controller;
+        // Generate the jobId client-side so the unmount cleanup can cancel
+        // the server-side batch immediately, even if it fires before the
+        // `started` SSE event arrives (which is the only place the server
+        // would otherwise echo back a server-chosen id).
+        const jobId = uuidv4();
+        jobIdRef.current = jobId;
         await batchPrint(
           widgets,
           settings,
           batch.rows.map((r) => r.values),
           batch.copies,
           batch.pauseTime,
+          jobId,
           (event: BatchEvent) => {
             switch (event.event) {
               case "started":
-                jobIdRef.current = event.jobId ?? null;
                 setStatus({
                   type: "loading",
                   message: `Starting batch of ${event.total}...`,

--- a/client/src/components/PrintButton.tsx
+++ b/client/src/components/PrintButton.tsx
@@ -14,10 +14,19 @@ export function PrintButton() {
   const jobIdRef = useRef<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
 
-  // On unmount, abort any in-flight batch stream so onProgress doesn't fire
-  // setStatus on a torn-down component.
+  // On unmount, abort the client-side SSE read AND tell the server to stop
+  // — otherwise the server-side print loop keeps running and the next mount
+  // will hit 409 until it finishes.
   useEffect(() => {
-    return () => abortRef.current?.abort();
+    return () => {
+      abortRef.current?.abort();
+      const jobId = jobIdRef.current;
+      if (jobId) {
+        cancelBatchPrint(jobId).catch(() => {
+          // Nothing useful to do on unmount.
+        });
+      }
+    };
   }, []);
 
   const totalLabels = batch.enabled

--- a/client/src/components/PrintButton.tsx
+++ b/client/src/components/PrintButton.tsx
@@ -89,7 +89,9 @@ export function PrintButton() {
 
   const handleCancel = () => {
     if (jobIdRef.current) {
-      cancelBatchPrint(jobIdRef.current);
+      cancelBatchPrint(jobIdRef.current).catch((err) => {
+        console.warn("Cancel batch failed:", err);
+      });
     }
   };
 

--- a/client/src/components/SaveLoadButtons.tsx
+++ b/client/src/components/SaveLoadButtons.tsx
@@ -5,6 +5,7 @@ import { exportLabel, importLabel } from "../lib/labelFile";
 export function SaveLoadButtons() {
   const widgets = useLabelStore((s) => s.widgets);
   const settings = useLabelStore((s) => s.settings);
+  const batch = useLabelStore((s) => s.batch);
   const loadLabel = useLabelStore((s) => s.loadLabel);
   const fileRef = useRef<HTMLInputElement>(null);
   const [busy, setBusy] = useState(false);
@@ -12,7 +13,7 @@ export function SaveLoadButtons() {
   const handleSave = async () => {
     setBusy(true);
     try {
-      const json = await exportLabel(widgets, settings);
+      const json = await exportLabel(widgets, settings, batch);
       const blob = new Blob([json], { type: "application/json" });
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
@@ -31,8 +32,8 @@ export function SaveLoadButtons() {
     setBusy(true);
     try {
       const json = await file.text();
-      const { widgets: w, settings: s } = await importLabel(json);
-      loadLabel(w, s);
+      const { widgets: w, settings: s, batch: b } = await importLabel(json);
+      loadLabel(w, s, b);
     } catch (err) {
       console.error("Load failed:", err);
     } finally {

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -18,6 +18,15 @@ interface PowerResponse extends PowerStatus {
   status?: string;
 }
 
+export interface BatchEvent {
+  event: "started" | "printing" | "printed" | "done" | "cancelled" | "error";
+  jobId?: string;
+  index?: number;
+  total?: number;
+  printed?: number;
+  message?: string;
+}
+
 export async function printLabel(
   widgets: LabelWidget[],
   settings: LabelSettings,
@@ -72,6 +81,58 @@ export async function fetchPrinters(): Promise<PrinterInfo[]> {
   }
   const data = (await res.json()) as PrintersResponse;
   return data.printers;
+}
+
+export async function batchPrint(
+  widgets: LabelWidget[],
+  settings: LabelSettings,
+  rows: Record<string, string>[],
+  copies: number,
+  pauseTime: number,
+  onProgress: (event: BatchEvent) => void,
+  signal?: AbortSignal,
+): Promise<void> {
+  const res = await fetch("/api/batch-print", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ widgets, settings, rows, copies, pauseTime }),
+    signal,
+  });
+
+  if (!res.ok) {
+    const err = (await res.json()) as PrintResponse;
+    throw new Error(err.message);
+  }
+
+  const reader = res.body?.getReader();
+  if (!reader) throw new Error("No response body");
+
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+
+    for (const line of lines) {
+      if (line.startsWith("data: ")) {
+        const event = JSON.parse(line.slice(6)) as BatchEvent;
+        onProgress(event);
+      }
+    }
+  }
+}
+
+export async function cancelBatchPrint(jobId: string): Promise<void> {
+  await fetch("/api/batch-print/cancel", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ jobId }),
+  });
 }
 
 // 404 here means the server can't resolve a controllable USB port for

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -100,8 +100,14 @@ export async function batchPrint(
   });
 
   if (!res.ok) {
-    const err = (await res.json()) as PrintResponse;
-    throw new Error(err.message);
+    let message = res.statusText || `HTTP ${res.status}`;
+    try {
+      const err = (await res.json()) as PrintResponse;
+      if (err.message) message = err.message;
+    } catch {
+      // Non-JSON body (e.g. nginx 502 HTML); fall back to statusText.
+    }
+    throw new Error(message);
   }
 
   const reader = res.body?.getReader();
@@ -120,8 +126,12 @@ export async function batchPrint(
 
     for (const line of lines) {
       if (line.startsWith("data: ")) {
-        const event = JSON.parse(line.slice(6)) as BatchEvent;
-        onProgress(event);
+        try {
+          const event = JSON.parse(line.slice(6)) as BatchEvent;
+          onProgress(event);
+        } catch (err) {
+          console.warn("Malformed SSE data line:", line, err);
+        }
       }
     }
   }

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -138,11 +138,21 @@ export async function batchPrint(
 }
 
 export async function cancelBatchPrint(jobId: string): Promise<void> {
-  await fetch("/api/batch-print/cancel", {
+  const res = await fetch("/api/batch-print/cancel", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ jobId }),
   });
+  if (!res.ok) {
+    let message = res.statusText || `HTTP ${res.status}`;
+    try {
+      const err = (await res.json()) as PrintResponse;
+      if (err.message) message = err.message;
+    } catch {
+      // Non-JSON body; fall back to statusText.
+    }
+    throw new Error(message);
+  }
 }
 
 // 404 here means the server can't resolve a controllable USB port for

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -89,13 +89,14 @@ export async function batchPrint(
   rows: Record<string, string>[],
   copies: number,
   pauseTime: number,
+  jobId: string,
   onProgress: (event: BatchEvent) => void,
   signal?: AbortSignal,
 ): Promise<void> {
   const res = await fetch("/api/batch-print", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ widgets, settings, rows, copies, pauseTime }),
+    body: JSON.stringify({ widgets, settings, rows, copies, pauseTime, jobId }),
     signal,
   });
 

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -5,11 +5,13 @@ export const TAPE_SIZES: TapeSize[] = [6, 9, 12, 19];
 export const DEFAULT_MARGIN_PX = 56;
 export const DEFAULT_FONT_SCALE = 90;
 
-// Mirror of MAX_BATCH_COPIES / MAX_BATCH_PAUSE_SECONDS in server/app.py.
-// Kept in sync manually — the server is the source of truth and will
-// reject out-of-range values with a 400.
+// Mirrors of MAX_BATCH_* in server/app.py. Kept in sync manually — the
+// server is the source of truth and will reject out-of-range values with
+// a 400. The client uses these to disable inputs at the cap so users
+// don't discover the limit only at print time.
 export const MAX_BATCH_COPIES = 999;
 export const MAX_BATCH_PAUSE_SECONDS = 60;
+export const MAX_BATCH_ROWS = 1000;
 
 export const BARCODE_TYPES: { value: BarcodeType; label: string }[] = [
   { value: "code128", label: "CODE128" },

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -5,6 +5,12 @@ export const TAPE_SIZES: TapeSize[] = [6, 9, 12, 19];
 export const DEFAULT_MARGIN_PX = 56;
 export const DEFAULT_FONT_SCALE = 90;
 
+// Mirror of MAX_BATCH_COPIES / MAX_BATCH_PAUSE_SECONDS in server/app.py.
+// Kept in sync manually — the server is the source of truth and will
+// reject out-of-range values with a 400.
+export const MAX_BATCH_COPIES = 999;
+export const MAX_BATCH_PAUSE_SECONDS = 60;
+
 export const BARCODE_TYPES: { value: BarcodeType; label: string }[] = [
   { value: "code128", label: "CODE128" },
   { value: "code39", label: "CODE39" },

--- a/client/src/lib/labelFile.ts
+++ b/client/src/lib/labelFile.ts
@@ -7,7 +7,6 @@ import { MAX_BATCH_COPIES, MAX_BATCH_PAUSE_SECONDS } from "./constants";
 // defaults, and `??` fallbacks at the use site only fire on
 // undefined — required types would lie about the runtime contract.
 interface LabelFileBatch {
-  enabled?: boolean;
   copies?: number;
   pauseTime?: number;
   rows?: Record<string, string>[];
@@ -30,7 +29,6 @@ function blobToDataUrl(blob: Blob): Promise<string> {
 }
 
 function _hasBatchData(batch: BatchState): boolean {
-  if (batch.enabled) return true;
   if (batch.copies !== 1) return true;
   if (batch.pauseTime !== 0) return true;
   if (batch.rows.length > 1) return true;
@@ -72,14 +70,12 @@ export async function exportLabel(
 
   const data: LabelFile = { version: 2, settings, widgets: exportWidgets };
 
-  // Export batch whenever the user has touched anything in the panel
-  // (rows with values, non-default copies/pause, or just the enabled
-  // flag itself). The `enabled` flag is persisted explicitly so the
-  // on/off state round-trips faithfully — previously unchecking
-  // "Enable batch printing" before saving silently dropped row data.
+  // Export the batch block whenever the user has touched anything in the
+  // panel (rows with values, or non-default copies/pause). Batch mode is
+  // derived from variable presence at runtime, so there's no on/off flag
+  // to persist.
   if (batch && _hasBatchData(batch)) {
     data.batch = {
-      enabled: batch.enabled,
       copies: batch.copies,
       pauseTime: batch.pauseTime,
       // Strip the internal `id` — it's a runtime React-key concern only.
@@ -139,10 +135,7 @@ export async function importLabel(
     ) {
       throw new Error("Invalid label file: batch must be an object");
     }
-    const { enabled, copies, pauseTime, rows } = data.batch;
-    if (enabled !== undefined && typeof enabled !== "boolean") {
-      throw new Error("Invalid label file: batch.enabled must be a boolean");
-    }
+    const { copies, pauseTime, rows } = data.batch;
     if (
       copies !== undefined &&
       (typeof copies !== "number" || copies < 1 || copies > MAX_BATCH_COPIES)
@@ -182,10 +175,6 @@ export async function importLabel(
       values,
     }));
     batch = {
-      // Pre-enabled-flag files (v2 before this change) get enabled=true
-      // for backward compat — only files exported by the new code will
-      // explicitly persist false.
-      enabled: enabled ?? true,
       copies: copies ?? 1,
       pauseTime: pauseTime ?? 0,
       rows: importedRows,

--- a/client/src/lib/labelFile.ts
+++ b/client/src/lib/labelFile.ts
@@ -111,7 +111,11 @@ export async function importLabel(
 
   let batch: BatchState | undefined;
   if (data.batch !== undefined) {
-    if (typeof data.batch !== "object" || data.batch === null) {
+    if (
+      typeof data.batch !== "object" ||
+      data.batch === null ||
+      Array.isArray(data.batch)
+    ) {
       throw new Error("Invalid label file: batch must be an object");
     }
     const { copies, pauseTime, rows } = data.batch;

--- a/client/src/lib/labelFile.ts
+++ b/client/src/lib/labelFile.ts
@@ -110,12 +110,41 @@ export async function importLabel(
   }
 
   let batch: BatchState | undefined;
-  if (data.batch) {
+  if (data.batch !== undefined) {
+    if (typeof data.batch !== "object" || data.batch === null) {
+      throw new Error("Invalid label file: batch must be an object");
+    }
+    const { copies, pauseTime, rows } = data.batch;
+    if (copies !== undefined && (typeof copies !== "number" || copies < 1)) {
+      throw new Error("Invalid label file: batch.copies must be a number >= 1");
+    }
+    if (
+      pauseTime !== undefined &&
+      (typeof pauseTime !== "number" || pauseTime < 0)
+    ) {
+      throw new Error("Invalid label file: batch.pauseTime must be a number >= 0");
+    }
+    if (rows !== undefined && !Array.isArray(rows)) {
+      throw new Error("Invalid label file: batch.rows must be an array");
+    }
+    if (rows) {
+      for (const row of rows) {
+        if (typeof row !== "object" || row === null || Array.isArray(row)) {
+          throw new Error("Invalid label file: batch.rows entries must be objects");
+        }
+        for (const v of Object.values(row)) {
+          if (typeof v !== "string") {
+            throw new Error("Invalid label file: batch.rows values must be strings");
+          }
+        }
+      }
+    }
+
     batch = {
       enabled: true,
-      copies: data.batch.copies ?? 1,
-      pauseTime: data.batch.pauseTime ?? 0,
-      rows: data.batch.rows?.length ? data.batch.rows : [{}],
+      copies: copies ?? 1,
+      pauseTime: pauseTime ?? 0,
+      rows: rows?.length ? rows : [{}],
       selectedRowIndex: null,
     };
   }

--- a/client/src/lib/labelFile.ts
+++ b/client/src/lib/labelFile.ts
@@ -7,6 +7,7 @@ import { MAX_BATCH_COPIES, MAX_BATCH_PAUSE_SECONDS } from "./constants";
 // defaults, and `??` fallbacks at the use site only fire on
 // undefined — required types would lie about the runtime contract.
 interface LabelFileBatch {
+  enabled?: boolean;
   copies?: number;
   pauseTime?: number;
   rows?: Record<string, string>[];
@@ -26,6 +27,15 @@ function blobToDataUrl(blob: Blob): Promise<string> {
     r.onerror = () => reject(r.error);
     r.readAsDataURL(blob);
   });
+}
+
+function _hasBatchData(batch: BatchState): boolean {
+  if (batch.enabled) return true;
+  if (batch.copies !== 1) return true;
+  if (batch.pauseTime !== 0) return true;
+  if (batch.rows.length > 1) return true;
+  if (batch.rows.some((r) => Object.keys(r.values).length > 0)) return true;
+  return false;
 }
 
 function dataUrlToFile(dataUrl: string, filename: string): File {
@@ -62,8 +72,14 @@ export async function exportLabel(
 
   const data: LabelFile = { version: 2, settings, widgets: exportWidgets };
 
-  if (batch?.enabled) {
+  // Export batch whenever the user has touched anything in the panel
+  // (rows with values, non-default copies/pause, or just the enabled
+  // flag itself). The `enabled` flag is persisted explicitly so the
+  // on/off state round-trips faithfully — previously unchecking
+  // "Enable batch printing" before saving silently dropped row data.
+  if (batch && _hasBatchData(batch)) {
     data.batch = {
+      enabled: batch.enabled,
       copies: batch.copies,
       pauseTime: batch.pauseTime,
       // Strip the internal `id` — it's a runtime React-key concern only.
@@ -123,7 +139,10 @@ export async function importLabel(
     ) {
       throw new Error("Invalid label file: batch must be an object");
     }
-    const { copies, pauseTime, rows } = data.batch;
+    const { enabled, copies, pauseTime, rows } = data.batch;
+    if (enabled !== undefined && typeof enabled !== "boolean") {
+      throw new Error("Invalid label file: batch.enabled must be a boolean");
+    }
     if (
       copies !== undefined &&
       (typeof copies !== "number" || copies < 1 || copies > MAX_BATCH_COPIES)
@@ -163,7 +182,10 @@ export async function importLabel(
       values,
     }));
     batch = {
-      enabled: true,
+      // Pre-enabled-flag files (v2 before this change) get enabled=true
+      // for backward compat — only files exported by the new code will
+      // explicitly persist false.
+      enabled: enabled ?? true,
       copies: copies ?? 1,
       pauseTime: pauseTime ?? 0,
       rows: importedRows,

--- a/client/src/lib/labelFile.ts
+++ b/client/src/lib/labelFile.ts
@@ -78,7 +78,12 @@ export async function importLabel(
 }> {
   const data = JSON.parse(json) as LabelFile;
 
-  if (!data.version || !data.widgets || !data.settings) {
+  if (
+    typeof data.version !== "number" ||
+    data.version < 1 ||
+    !data.widgets ||
+    !data.settings
+  ) {
     throw new Error("Invalid label file");
   }
   if (data.version > 2) {

--- a/client/src/lib/labelFile.ts
+++ b/client/src/lib/labelFile.ts
@@ -66,7 +66,8 @@ export async function exportLabel(
     data.batch = {
       copies: batch.copies,
       pauseTime: batch.pauseTime,
-      rows: batch.rows,
+      // Strip the internal `id` — it's a runtime React-key concern only.
+      rows: batch.rows.map((r) => r.values),
     };
   }
 
@@ -157,11 +158,15 @@ export async function importLabel(
       }
     }
 
+    const importedRows = (rows?.length ? rows : [{}]).map((values) => ({
+      id: uuidv4(),
+      values,
+    }));
     batch = {
       enabled: true,
       copies: copies ?? 1,
       pauseTime: pauseTime ?? 0,
-      rows: rows?.length ? rows : [{}],
+      rows: importedRows,
       selectedRowIndex: null,
     };
   }

--- a/client/src/lib/labelFile.ts
+++ b/client/src/lib/labelFile.ts
@@ -1,11 +1,15 @@
 import { v4 as uuidv4 } from "uuid";
 import type { LabelWidget, LabelSettings, BatchState } from "../types/label";
 import { uploadImage } from "./api";
+import { MAX_BATCH_COPIES, MAX_BATCH_PAUSE_SECONDS } from "./constants";
 
+// All fields optional: importLabel tolerates missing keys with safe
+// defaults, and `??` fallbacks at the use site only fire on
+// undefined — required types would lie about the runtime contract.
 interface LabelFileBatch {
-  copies: number;
-  pauseTime: number;
-  rows: Record<string, string>[];
+  copies?: number;
+  pauseTime?: number;
+  rows?: Record<string, string>[];
 }
 
 interface LabelFile {
@@ -119,14 +123,23 @@ export async function importLabel(
       throw new Error("Invalid label file: batch must be an object");
     }
     const { copies, pauseTime, rows } = data.batch;
-    if (copies !== undefined && (typeof copies !== "number" || copies < 1)) {
-      throw new Error("Invalid label file: batch.copies must be a number >= 1");
+    if (
+      copies !== undefined &&
+      (typeof copies !== "number" || copies < 1 || copies > MAX_BATCH_COPIES)
+    ) {
+      throw new Error(
+        `Invalid label file: batch.copies must be a number between 1 and ${MAX_BATCH_COPIES}`,
+      );
     }
     if (
       pauseTime !== undefined &&
-      (typeof pauseTime !== "number" || pauseTime < 0)
+      (typeof pauseTime !== "number" ||
+        pauseTime < 0 ||
+        pauseTime > MAX_BATCH_PAUSE_SECONDS)
     ) {
-      throw new Error("Invalid label file: batch.pauseTime must be a number >= 0");
+      throw new Error(
+        `Invalid label file: batch.pauseTime must be a number between 0 and ${MAX_BATCH_PAUSE_SECONDS}`,
+      );
     }
     if (rows !== undefined && !Array.isArray(rows)) {
       throw new Error("Invalid label file: batch.rows must be an array");

--- a/client/src/lib/labelFile.ts
+++ b/client/src/lib/labelFile.ts
@@ -81,6 +81,11 @@ export async function importLabel(
   if (!data.version || !data.widgets || !data.settings) {
     throw new Error("Invalid label file");
   }
+  if (data.version > 2) {
+    throw new Error(
+      `Unsupported label file version ${data.version}. Update Labelle Web to load this file.`,
+    );
+  }
 
   const widgets: LabelWidget[] = [];
 

--- a/client/src/lib/variables.ts
+++ b/client/src/lib/variables.ts
@@ -1,0 +1,44 @@
+import type { LabelWidget } from "../types/label";
+
+const VAR_REGEX = /:([a-zA-Z_]\w*):/g;
+
+export function detectVariables(widgets: LabelWidget[]): string[] {
+  const vars = new Set<string>();
+  for (const w of widgets) {
+    let text: string | undefined;
+    if (w.type === "text") text = w.text;
+    else if (w.type === "qr" || w.type === "barcode") text = w.content;
+    if (text) {
+      for (const match of text.matchAll(VAR_REGEX)) {
+        const name = match[1];
+        if (name) vars.add(name);
+      }
+    }
+  }
+  return [...vars];
+}
+
+export function substituteWidgets(
+  widgets: LabelWidget[],
+  values: Record<string, string>,
+): LabelWidget[] {
+  return widgets.map((w) => {
+    if (w.type === "text") {
+      return { ...w, text: replaceVars(w.text, values) };
+    }
+    if (w.type === "qr") {
+      return { ...w, content: replaceVars(w.content, values) };
+    }
+    if (w.type === "barcode") {
+      return { ...w, content: replaceVars(w.content, values) };
+    }
+    return w;
+  });
+}
+
+function replaceVars(text: string, values: Record<string, string>): string {
+  return text.replace(VAR_REGEX, (match, name: string) => {
+    const val = values[name];
+    return val !== undefined ? val : match;
+  });
+}

--- a/client/src/lib/variables.ts
+++ b/client/src/lib/variables.ts
@@ -1,6 +1,6 @@
 import type { LabelWidget } from "../types/label";
 
-const VAR_REGEX = /:([a-zA-Z_]\w*):/g;
+const VAR_REGEX = /:(\w+):/g;
 
 export function detectVariables(widgets: LabelWidget[]): string[] {
   const vars = new Set<string>();

--- a/client/src/state/useLabelStore.test.ts
+++ b/client/src/state/useLabelStore.test.ts
@@ -185,7 +185,6 @@ describe("Variable rename in batch rows", () => {
     const id = seedTextWidgetWith("Hi :name:");
     useLabelStore.setState({
       batch: {
-        enabled: true,
         copies: 1,
         pauseTime: 0,
         rows: seedRows([{ name: "Alice" }, { name: "Bob" }]),
@@ -203,7 +202,6 @@ describe("Variable rename in batch rows", () => {
     const id = seedTextWidgetWith(":name:");
     useLabelStore.setState({
       batch: {
-        enabled: true,
         copies: 1,
         pauseTime: 0,
         rows: seedRows([{ name: "Alice" }]),
@@ -220,7 +218,6 @@ describe("Variable rename in batch rows", () => {
     const id = seedTextWidgetWith(":name:");
     useLabelStore.setState({
       batch: {
-        enabled: true,
         copies: 1,
         pauseTime: 0,
         rows: seedRows([{ name: "Alice" }]),
@@ -237,7 +234,6 @@ describe("Variable rename in batch rows", () => {
     const id = seedTextWidgetWith(":name: :age:");
     useLabelStore.setState({
       batch: {
-        enabled: true,
         copies: 1,
         pauseTime: 0,
         rows: seedRows([{ name: "Alice", age: "30" }]),
@@ -255,7 +251,6 @@ describe("Variable rename in batch rows", () => {
     const id = seedTextWidgetWith(":name:");
     useLabelStore.setState({
       batch: {
-        enabled: true,
         copies: 1,
         pauseTime: 0,
         rows: seedRows([{ name: "Alice" }]),
@@ -284,7 +279,6 @@ describe("Variable rename in batch rows", () => {
         { id: "w3", type: "barcode", content: ":name:", barcodeType: "code128", showText: false },
       ],
       batch: {
-        enabled: true,
         copies: 1,
         pauseTime: 0,
         rows: seedRows([{ name: "Alice" }]),
@@ -328,7 +322,6 @@ describe("Variable rename in batch rows", () => {
         },
       ],
       batch: {
-        enabled: true,
         copies: 1,
         pauseTime: 0,
         rows: seedRows([{ name: "Alice", age: "30" }]),

--- a/client/src/state/useLabelStore.test.ts
+++ b/client/src/state/useLabelStore.test.ts
@@ -173,6 +173,14 @@ describe("Variable rename in batch rows", () => {
     return "w1";
   }
 
+  function seedRows(values: Record<string, string>[]) {
+    return values.map((v, i) => ({ id: `r${i}`, values: v }));
+  }
+
+  function rowValues(idx = 0) {
+    return useLabelStore.getState().batch.rows[idx]?.values;
+  }
+
   it("carries batch row values from old name to new on rename", () => {
     const id = seedTextWidgetWith("Hi :name:");
     useLabelStore.setState({
@@ -180,16 +188,15 @@ describe("Variable rename in batch rows", () => {
         enabled: true,
         copies: 1,
         pauseTime: 0,
-        rows: [{ name: "Alice" }, { name: "Bob" }],
+        rows: seedRows([{ name: "Alice" }, { name: "Bob" }]),
         selectedRowIndex: null,
       },
     });
 
     useLabelStore.getState().updateWidget(id, { text: "Hi :full_name:" });
 
-    const rows = useLabelStore.getState().batch.rows;
-    expect(rows[0]).toEqual({ full_name: "Alice" });
-    expect(rows[1]).toEqual({ full_name: "Bob" });
+    expect(rowValues(0)).toEqual({ full_name: "Alice" });
+    expect(rowValues(1)).toEqual({ full_name: "Bob" });
   });
 
   it("carries values through incremental typing edits", () => {
@@ -199,14 +206,14 @@ describe("Variable rename in batch rows", () => {
         enabled: true,
         copies: 1,
         pauseTime: 0,
-        rows: [{ name: "Alice" }],
+        rows: seedRows([{ name: "Alice" }]),
         selectedRowIndex: null,
       },
     });
 
     // Simulate typing "name" -> "names"
     useLabelStore.getState().updateWidget(id, { text: ":names:" });
-    expect(useLabelStore.getState().batch.rows[0]).toEqual({ names: "Alice" });
+    expect(rowValues(0)).toEqual({ names: "Alice" });
   });
 
   it("does not touch rows when a variable is purely added", () => {
@@ -216,14 +223,14 @@ describe("Variable rename in batch rows", () => {
         enabled: true,
         copies: 1,
         pauseTime: 0,
-        rows: [{ name: "Alice" }],
+        rows: seedRows([{ name: "Alice" }]),
         selectedRowIndex: null,
       },
     });
 
     useLabelStore.getState().updateWidget(id, { text: ":name: :age:" });
 
-    expect(useLabelStore.getState().batch.rows[0]).toEqual({ name: "Alice" });
+    expect(rowValues(0)).toEqual({ name: "Alice" });
   });
 
   it("does not touch rows when a variable is purely removed", () => {
@@ -233,7 +240,7 @@ describe("Variable rename in batch rows", () => {
         enabled: true,
         copies: 1,
         pauseTime: 0,
-        rows: [{ name: "Alice", age: "30" }],
+        rows: seedRows([{ name: "Alice", age: "30" }]),
         selectedRowIndex: null,
       },
     });
@@ -241,10 +248,24 @@ describe("Variable rename in batch rows", () => {
     useLabelStore.getState().updateWidget(id, { text: ":name:" });
 
     // age value orphans but isn't reassigned to something else
-    expect(useLabelStore.getState().batch.rows[0]).toEqual({
-      name: "Alice",
-      age: "30",
+    expect(rowValues(0)).toEqual({ name: "Alice", age: "30" });
+  });
+
+  it("preserves row id across rename migration", () => {
+    const id = seedTextWidgetWith(":name:");
+    useLabelStore.setState({
+      batch: {
+        enabled: true,
+        copies: 1,
+        pauseTime: 0,
+        rows: seedRows([{ name: "Alice" }]),
+        selectedRowIndex: null,
+      },
     });
+
+    useLabelStore.getState().updateWidget(id, { text: ":full_name:" });
+
+    expect(useLabelStore.getState().batch.rows[0]?.id).toBe("r0");
   });
 
   it("propagates rename to other widgets that reference the same variable", () => {
@@ -266,7 +287,7 @@ describe("Variable rename in batch rows", () => {
         enabled: true,
         copies: 1,
         pauseTime: 0,
-        rows: [{ name: "Alice" }],
+        rows: seedRows([{ name: "Alice" }]),
         selectedRowIndex: null,
       },
     });
@@ -277,7 +298,7 @@ describe("Variable rename in batch rows", () => {
     expect((widgets[0] as { text: string }).text).toBe("Hello :full_name:");
     expect((widgets[1] as { content: string }).content).toBe("user/:full_name:");
     expect((widgets[2] as { content: string }).content).toBe(":full_name:");
-    expect(useLabelStore.getState().batch.rows[0]).toEqual({ full_name: "Alice" });
+    expect(rowValues(0)).toEqual({ full_name: "Alice" });
   });
 
   it("does not propagate when a different widget gets an unrelated edit", () => {
@@ -310,7 +331,7 @@ describe("Variable rename in batch rows", () => {
         enabled: true,
         copies: 1,
         pauseTime: 0,
-        rows: [{ name: "Alice", age: "30" }],
+        rows: seedRows([{ name: "Alice", age: "30" }]),
         selectedRowIndex: null,
       },
     });
@@ -320,9 +341,6 @@ describe("Variable rename in batch rows", () => {
 
     // Row data should be unchanged — age value orphans but name is not
     // migrated into age (or vice versa).
-    expect(useLabelStore.getState().batch.rows[0]).toEqual({
-      name: "Alice",
-      age: "30",
-    });
+    expect(rowValues(0)).toEqual({ name: "Alice", age: "30" });
   });
 });

--- a/client/src/state/useLabelStore.test.ts
+++ b/client/src/state/useLabelStore.test.ts
@@ -246,4 +246,83 @@ describe("Variable rename in batch rows", () => {
       age: "30",
     });
   });
+
+  it("propagates rename to other widgets that reference the same variable", () => {
+    useLabelStore.setState({
+      widgets: [
+        {
+          id: "w1",
+          type: "text",
+          text: "Hello :name:",
+          fontStyle: "regular",
+          fontScale: DEFAULT_FONT_SCALE,
+          frameWidthPx: 0,
+          align: "left",
+        },
+        { id: "w2", type: "qr", content: "user/:name:" },
+        { id: "w3", type: "barcode", content: ":name:", barcodeType: "code128", showText: false },
+      ],
+      batch: {
+        enabled: true,
+        copies: 1,
+        pauseTime: 0,
+        rows: [{ name: "Alice" }],
+        selectedRowIndex: null,
+      },
+    });
+
+    useLabelStore.getState().updateWidget("w1", { text: "Hello :full_name:" });
+
+    const widgets = useLabelStore.getState().widgets;
+    expect((widgets[0] as { text: string }).text).toBe("Hello :full_name:");
+    expect((widgets[1] as { content: string }).content).toBe("user/:full_name:");
+    expect((widgets[2] as { content: string }).content).toBe(":full_name:");
+    expect(useLabelStore.getState().batch.rows[0]).toEqual({ full_name: "Alice" });
+  });
+
+  it("does not propagate when a different widget gets an unrelated edit", () => {
+    // Two unrelated edits in different widgets — without per-widget scoping
+    // the heuristic could see {removed:[a], added:[b]} from cross-widget
+    // bookkeeping and incorrectly carry values. Per-widget scoping prevents
+    // this: removing var from B doesn't migrate A's row data.
+    useLabelStore.setState({
+      widgets: [
+        {
+          id: "w1",
+          type: "text",
+          text: ":name:",
+          fontStyle: "regular",
+          fontScale: DEFAULT_FONT_SCALE,
+          frameWidthPx: 0,
+          align: "left",
+        },
+        {
+          id: "w2",
+          type: "text",
+          text: ":age:",
+          fontStyle: "regular",
+          fontScale: DEFAULT_FONT_SCALE,
+          frameWidthPx: 0,
+          align: "left",
+        },
+      ],
+      batch: {
+        enabled: true,
+        copies: 1,
+        pauseTime: 0,
+        rows: [{ name: "Alice", age: "30" }],
+        selectedRowIndex: null,
+      },
+    });
+
+    // Remove :age: from widget 2 only (a pure removal).
+    useLabelStore.getState().updateWidget("w2", { text: "" });
+
+    // Row data should be unchanged — age value orphans but name is not
+    // migrated into age (or vice versa).
+    expect(useLabelStore.getState().batch.rows[0]).toEqual({
+      name: "Alice",
+      age: "30",
+    });
+  });
 });

--- a/client/src/state/useLabelStore.test.ts
+++ b/client/src/state/useLabelStore.test.ts
@@ -154,3 +154,96 @@ describe("Load", () => {
     expect(useLabelStore.getState().settings).toEqual(settings);
   });
 });
+
+describe("Variable rename in batch rows", () => {
+  function seedTextWidgetWith(text: string): string {
+    useLabelStore.setState({
+      widgets: [
+        {
+          id: "w1",
+          type: "text",
+          text,
+          fontStyle: "regular",
+          fontScale: DEFAULT_FONT_SCALE,
+          frameWidthPx: 0,
+          align: "left",
+        },
+      ],
+    });
+    return "w1";
+  }
+
+  it("carries batch row values from old name to new on rename", () => {
+    const id = seedTextWidgetWith("Hi :name:");
+    useLabelStore.setState({
+      batch: {
+        enabled: true,
+        copies: 1,
+        pauseTime: 0,
+        rows: [{ name: "Alice" }, { name: "Bob" }],
+        selectedRowIndex: null,
+      },
+    });
+
+    useLabelStore.getState().updateWidget(id, { text: "Hi :full_name:" });
+
+    const rows = useLabelStore.getState().batch.rows;
+    expect(rows[0]).toEqual({ full_name: "Alice" });
+    expect(rows[1]).toEqual({ full_name: "Bob" });
+  });
+
+  it("carries values through incremental typing edits", () => {
+    const id = seedTextWidgetWith(":name:");
+    useLabelStore.setState({
+      batch: {
+        enabled: true,
+        copies: 1,
+        pauseTime: 0,
+        rows: [{ name: "Alice" }],
+        selectedRowIndex: null,
+      },
+    });
+
+    // Simulate typing "name" -> "names"
+    useLabelStore.getState().updateWidget(id, { text: ":names:" });
+    expect(useLabelStore.getState().batch.rows[0]).toEqual({ names: "Alice" });
+  });
+
+  it("does not touch rows when a variable is purely added", () => {
+    const id = seedTextWidgetWith(":name:");
+    useLabelStore.setState({
+      batch: {
+        enabled: true,
+        copies: 1,
+        pauseTime: 0,
+        rows: [{ name: "Alice" }],
+        selectedRowIndex: null,
+      },
+    });
+
+    useLabelStore.getState().updateWidget(id, { text: ":name: :age:" });
+
+    expect(useLabelStore.getState().batch.rows[0]).toEqual({ name: "Alice" });
+  });
+
+  it("does not touch rows when a variable is purely removed", () => {
+    const id = seedTextWidgetWith(":name: :age:");
+    useLabelStore.setState({
+      batch: {
+        enabled: true,
+        copies: 1,
+        pauseTime: 0,
+        rows: [{ name: "Alice", age: "30" }],
+        selectedRowIndex: null,
+      },
+    });
+
+    useLabelStore.getState().updateWidget(id, { text: ":name:" });
+
+    // age value orphans but isn't reassigned to something else
+    expect(useLabelStore.getState().batch.rows[0]).toEqual({
+      name: "Alice",
+      age: "30",
+    });
+  });
+});

--- a/client/src/state/useLabelStore.ts
+++ b/client/src/state/useLabelStore.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from "uuid";
 import type {
   LabelWidget,
   LabelSettings,
+  BatchState,
   TextWidget,
   QrWidget,
   BarcodeWidget,
@@ -11,10 +12,19 @@ import type {
 } from "../types/label";
 import { DEFAULT_MARGIN_PX, DEFAULT_FONT_SCALE } from "../lib/constants";
 
+const DEFAULT_BATCH: BatchState = {
+  enabled: false,
+  copies: 1,
+  pauseTime: 0,
+  rows: [{}],
+  selectedRowIndex: null,
+};
+
 interface LabelStore {
   widgets: LabelWidget[];
   settings: LabelSettings;
   availablePrinters: PrinterInfo[];
+  batch: BatchState;
 
   addTextWidget: () => void;
   addQrWidget: () => void;
@@ -25,7 +35,15 @@ interface LabelStore {
   updateWidget: (id: string, patch: Partial<LabelWidget>) => void;
   updateSettings: (patch: Partial<LabelSettings>) => void;
   setAvailablePrinters: (printers: PrinterInfo[]) => void;
-  loadLabel: (widgets: LabelWidget[], settings: LabelSettings) => void;
+  updateBatch: (patch: Partial<BatchState>) => void;
+  setBatchRow: (rowIndex: number, varName: string, value: string) => void;
+  addBatchRow: () => void;
+  removeBatchRow: (index: number) => void;
+  loadLabel: (
+    widgets: LabelWidget[],
+    settings: LabelSettings,
+    batch?: BatchState,
+  ) => void;
 }
 
 export const useLabelStore = create<LabelStore>((set) => ({
@@ -52,6 +70,8 @@ export const useLabelStore = create<LabelStore>((set) => ({
   },
 
   availablePrinters: [],
+
+  batch: { ...DEFAULT_BATCH },
 
   addTextWidget: () =>
     set((s) => ({
@@ -132,5 +152,35 @@ export const useLabelStore = create<LabelStore>((set) => ({
 
   setAvailablePrinters: (printers) => set({ availablePrinters: printers }),
 
-  loadLabel: (widgets, settings) => set({ widgets, settings }),
+  updateBatch: (patch) =>
+    set((s) => ({ batch: { ...s.batch, ...patch } })),
+
+  setBatchRow: (rowIndex, varName, value) =>
+    set((s) => {
+      const rows = s.batch.rows.map((row, i) =>
+        i === rowIndex ? { ...row, [varName]: value } : row,
+      );
+      return { batch: { ...s.batch, rows } };
+    }),
+
+  addBatchRow: () =>
+    set((s) => ({
+      batch: { ...s.batch, rows: [...s.batch.rows, {}] },
+    })),
+
+  removeBatchRow: (index) =>
+    set((s) => {
+      const rows = s.batch.rows.filter((_, i) => i !== index);
+      const selectedRowIndex =
+        s.batch.selectedRowIndex === index
+          ? null
+          : s.batch.selectedRowIndex !== null &&
+              s.batch.selectedRowIndex > index
+            ? s.batch.selectedRowIndex - 1
+            : s.batch.selectedRowIndex;
+      return { batch: { ...s.batch, rows: rows.length ? rows : [{}], selectedRowIndex } };
+    }),
+
+  loadLabel: (widgets, settings, batch) =>
+    set({ widgets, settings, batch: batch ?? { ...DEFAULT_BATCH } }),
 }));

--- a/client/src/state/useLabelStore.ts
+++ b/client/src/state/useLabelStore.ts
@@ -19,7 +19,6 @@ function newBatchRow(values: Record<string, string> = {}) {
 
 function defaultBatch(): BatchState {
   return {
-    enabled: false,
     copies: 1,
     pauseTime: 0,
     rows: [newBatchRow()],

--- a/client/src/state/useLabelStore.ts
+++ b/client/src/state/useLabelStore.ts
@@ -189,6 +189,11 @@ export const useLabelStore = create<LabelStore>((set) => ({
           return w;
         });
 
+        // Migrate row keys. If `newName` already existed in the row
+        // (e.g. user renamed `:name:` -> `:full_name:` while another
+        // widget already used `:full_name:`), the rename takes
+        // precedence and the prior value is overwritten — the user's
+        // most recent edit wins.
         const rows: Record<string, string>[] = s.batch.rows.map((row) => {
           if (!(oldName in row)) return row;
           const value = row[oldName] ?? "";

--- a/client/src/state/useLabelStore.ts
+++ b/client/src/state/useLabelStore.ts
@@ -13,13 +13,19 @@ import type {
 import { DEFAULT_MARGIN_PX, DEFAULT_FONT_SCALE } from "../lib/constants";
 import { detectVariables } from "../lib/variables";
 
-const DEFAULT_BATCH: BatchState = {
-  enabled: false,
-  copies: 1,
-  pauseTime: 0,
-  rows: [{}],
-  selectedRowIndex: null,
-};
+function newBatchRow(values: Record<string, string> = {}) {
+  return { id: uuidv4(), values };
+}
+
+function defaultBatch(): BatchState {
+  return {
+    enabled: false,
+    copies: 1,
+    pauseTime: 0,
+    rows: [newBatchRow()],
+    selectedRowIndex: null,
+  };
+}
 
 interface LabelStore {
   widgets: LabelWidget[];
@@ -72,7 +78,7 @@ export const useLabelStore = create<LabelStore>((set) => ({
 
   availablePrinters: [],
 
-  batch: { ...DEFAULT_BATCH },
+  batch: defaultBatch(),
 
   addTextWidget: () => {
     const id = uuidv4();
@@ -189,20 +195,20 @@ export const useLabelStore = create<LabelStore>((set) => ({
           return w;
         });
 
-        // Migrate row keys. If `newName` already existed in the row
-        // (e.g. user renamed `:name:` -> `:full_name:` while another
-        // widget already used `:full_name:`), the rename takes
+        // Migrate row values keys. If `newName` already existed in the
+        // row (e.g. user renamed `:name:` -> `:full_name:` while
+        // another widget already used `:full_name:`), the rename takes
         // precedence and the prior value is overwritten — the user's
         // most recent edit wins.
-        const rows: Record<string, string>[] = s.batch.rows.map((row) => {
-          if (!(oldName in row)) return row;
-          const value = row[oldName] ?? "";
-          const next: Record<string, string> = {};
-          for (const [k, v] of Object.entries(row)) {
-            if (k !== oldName) next[k] = v;
+        const rows = s.batch.rows.map((row) => {
+          if (!(oldName in row.values)) return row;
+          const value = row.values[oldName] ?? "";
+          const nextValues: Record<string, string> = {};
+          for (const [k, v] of Object.entries(row.values)) {
+            if (k !== oldName) nextValues[k] = v;
           }
-          next[newName] = value;
-          return next;
+          nextValues[newName] = value;
+          return { ...row, values: nextValues };
         });
 
         return { widgets, batch: { ...s.batch, rows } };
@@ -223,14 +229,16 @@ export const useLabelStore = create<LabelStore>((set) => ({
   setBatchRow: (rowIndex, varName, value) =>
     set((s) => {
       const rows = s.batch.rows.map((row, i) =>
-        i === rowIndex ? { ...row, [varName]: value } : row,
+        i === rowIndex
+          ? { ...row, values: { ...row.values, [varName]: value } }
+          : row,
       );
       return { batch: { ...s.batch, rows } };
     }),
 
   addBatchRow: () =>
     set((s) => ({
-      batch: { ...s.batch, rows: [...s.batch.rows, {}] },
+      batch: { ...s.batch, rows: [...s.batch.rows, newBatchRow()] },
     })),
 
   removeBatchRow: (index) =>
@@ -243,9 +251,15 @@ export const useLabelStore = create<LabelStore>((set) => ({
               s.batch.selectedRowIndex > index
             ? s.batch.selectedRowIndex - 1
             : s.batch.selectedRowIndex;
-      return { batch: { ...s.batch, rows: rows.length ? rows : [{}], selectedRowIndex } };
+      return {
+        batch: {
+          ...s.batch,
+          rows: rows.length ? rows : [newBatchRow()],
+          selectedRowIndex,
+        },
+      };
     }),
 
   loadLabel: (widgets, settings, batch) =>
-    set({ widgets, settings, batch: batch ?? { ...DEFAULT_BATCH } }),
+    set({ widgets, settings, batch: batch ?? defaultBatch() }),
 }));

--- a/client/src/state/useLabelStore.ts
+++ b/client/src/state/useLabelStore.ts
@@ -153,6 +153,15 @@ export const useLabelStore = create<LabelStore>((set) => ({
       // Scoping to one widget avoids the cross-widget false-positive where
       // unrelated edits in two widgets could each contribute a single add
       // and remove.
+      //
+      // Known limitation: keystroke-by-keystroke typing in a controlled
+      // <input> (e.g. :name: -> :names -> :names:) hits an intermediate
+      // state with no closing colon, where detectVariables returns [].
+      // The transition then looks like a pure removal followed (one
+      // keystroke later) by a pure addition — neither half triggers the
+      // rename branch, and the row value for the old name orphans. In
+      // practice users edit via select-and-replace or paste, which works.
+      // See docs/ARCHITECTURE.md "Variable rename heuristic" for context.
       const before = detectVariables([oldWidget]);
       const after = detectVariables([newWidget]);
       const removed = before.filter((v) => !after.includes(v));

--- a/client/src/state/useLabelStore.ts
+++ b/client/src/state/useLabelStore.ts
@@ -143,21 +143,40 @@ export const useLabelStore = create<LabelStore>((set) => ({
 
   updateWidget: (id, patch) =>
     set((s) => {
-      const widgets = s.widgets.map((w) =>
-        w.id === id ? ({ ...w, ...patch } as LabelWidget) : w,
-      );
+      const oldWidget = s.widgets.find((w) => w.id === id);
+      if (!oldWidget) return s;
+      const newWidget = { ...oldWidget, ...patch } as LabelWidget;
 
-      // Variable rename detection: if exactly one variable name disappeared
-      // and exactly one new one appeared, treat it as a rename and carry the
-      // batch row values across. Anything more ambiguous (added without
-      // removing, removed without adding, multiple of each) leaves rows alone.
-      const before = detectVariables(s.widgets);
-      const after = detectVariables(widgets);
+      // Variable rename detection: compare variables in JUST the changed
+      // widget. If exactly one disappeared and one appeared, treat it as a
+      // rename — propagate to other widgets and migrate the batch row key.
+      // Scoping to one widget avoids the cross-widget false-positive where
+      // unrelated edits in two widgets could each contribute a single add
+      // and remove.
+      const before = detectVariables([oldWidget]);
+      const after = detectVariables([newWidget]);
       const removed = before.filter((v) => !after.includes(v));
       const added = after.filter((v) => !before.includes(v));
+
       if (removed.length === 1 && added.length === 1) {
         const oldName = removed[0]!;
         const newName = added[0]!;
+        // Variable names match \w+ — no regex escaping needed.
+        const placeholderRe = new RegExp(`:${oldName}:`, "g");
+        const newPlaceholder = `:${newName}:`;
+
+        const widgets = s.widgets.map((w) => {
+          if (w.id === id) return newWidget;
+          if (w.type === "text")
+            return { ...w, text: w.text.replace(placeholderRe, newPlaceholder) };
+          if (w.type === "qr" || w.type === "barcode")
+            return {
+              ...w,
+              content: w.content.replace(placeholderRe, newPlaceholder),
+            };
+          return w;
+        });
+
         const rows: Record<string, string>[] = s.batch.rows.map((row) => {
           if (!(oldName in row)) return row;
           const value = row[oldName] ?? "";
@@ -168,9 +187,11 @@ export const useLabelStore = create<LabelStore>((set) => ({
           next[newName] = value;
           return next;
         });
+
         return { widgets, batch: { ...s.batch, rows } };
       }
 
+      const widgets = s.widgets.map((w) => (w.id === id ? newWidget : w));
       return { widgets };
     }),
 

--- a/client/src/state/useLabelStore.ts
+++ b/client/src/state/useLabelStore.ts
@@ -158,10 +158,15 @@ export const useLabelStore = create<LabelStore>((set) => ({
       if (removed.length === 1 && added.length === 1) {
         const oldName = removed[0]!;
         const newName = added[0]!;
-        const rows = s.batch.rows.map((row) => {
+        const rows: Record<string, string>[] = s.batch.rows.map((row) => {
           if (!(oldName in row)) return row;
-          const { [oldName]: value, ...rest } = row;
-          return { ...rest, [newName]: value };
+          const value = row[oldName] ?? "";
+          const next: Record<string, string> = {};
+          for (const [k, v] of Object.entries(row)) {
+            if (k !== oldName) next[k] = v;
+          }
+          next[newName] = value;
+          return next;
         });
         return { widgets, batch: { ...s.batch, rows } };
       }

--- a/client/src/state/useLabelStore.ts
+++ b/client/src/state/useLabelStore.ts
@@ -11,6 +11,7 @@ import type {
   PrinterInfo,
 } from "../types/label";
 import { DEFAULT_MARGIN_PX, DEFAULT_FONT_SCALE } from "../lib/constants";
+import { detectVariables } from "../lib/variables";
 
 const DEFAULT_BATCH: BatchState = {
   enabled: false,
@@ -141,11 +142,32 @@ export const useLabelStore = create<LabelStore>((set) => ({
     }),
 
   updateWidget: (id, patch) =>
-    set((s) => ({
-      widgets: s.widgets.map((w) =>
+    set((s) => {
+      const widgets = s.widgets.map((w) =>
         w.id === id ? ({ ...w, ...patch } as LabelWidget) : w,
-      ),
-    })),
+      );
+
+      // Variable rename detection: if exactly one variable name disappeared
+      // and exactly one new one appeared, treat it as a rename and carry the
+      // batch row values across. Anything more ambiguous (added without
+      // removing, removed without adding, multiple of each) leaves rows alone.
+      const before = detectVariables(s.widgets);
+      const after = detectVariables(widgets);
+      const removed = before.filter((v) => !after.includes(v));
+      const added = after.filter((v) => !before.includes(v));
+      if (removed.length === 1 && added.length === 1) {
+        const oldName = removed[0]!;
+        const newName = added[0]!;
+        const rows = s.batch.rows.map((row) => {
+          if (!(oldName in row)) return row;
+          const { [oldName]: value, ...rest } = row;
+          return { ...rest, [newName]: value };
+        });
+        return { widgets, batch: { ...s.batch, rows } };
+      }
+
+      return { widgets };
+    }),
 
   updateSettings: (patch) =>
     set((s) => ({ settings: { ...s.settings, ...patch } })),

--- a/client/src/state/useLabelStore.ts
+++ b/client/src/state/useLabelStore.ts
@@ -27,7 +27,7 @@ interface LabelStore {
   availablePrinters: PrinterInfo[];
   batch: BatchState;
 
-  addTextWidget: () => void;
+  addTextWidget: () => string;
   addQrWidget: () => void;
   addBarcodeWidget: () => void;
   addImageWidget: (filename: string) => void;
@@ -74,12 +74,13 @@ export const useLabelStore = create<LabelStore>((set) => ({
 
   batch: { ...DEFAULT_BATCH },
 
-  addTextWidget: () =>
+  addTextWidget: () => {
+    const id = uuidv4();
     set((s) => ({
       widgets: [
         ...s.widgets,
         {
-          id: uuidv4(),
+          id,
           type: "text",
           text: "",
           fontStyle: "regular",
@@ -88,7 +89,9 @@ export const useLabelStore = create<LabelStore>((set) => ({
           align: "left",
         } satisfies TextWidget,
       ],
-    })),
+    }));
+    return id;
+  },
 
   addQrWidget: () =>
     set((s) => ({

--- a/client/src/types/label.ts
+++ b/client/src/types/label.ts
@@ -82,8 +82,10 @@ export interface BatchRow {
   values: Record<string, string>;
 }
 
+// Batch mode is active when the widgets contain :variable: placeholders;
+// there is no explicit on/off flag. `rows` holds the per-label values that
+// only get exercised once variables exist.
 export interface BatchState {
-  enabled: boolean;
   copies: number;
   pauseTime: number;
   rows: BatchRow[];

--- a/client/src/types/label.ts
+++ b/client/src/types/label.ts
@@ -75,6 +75,14 @@ export interface PowerStatus {
   connected: boolean;
 }
 
+export interface BatchState {
+  enabled: boolean;
+  copies: number;
+  pauseTime: number;
+  rows: Record<string, string>[];
+  selectedRowIndex: number | null;
+}
+
 export interface LabelSettings {
   tapeSizeMm: TapeSize;
   marginPx: number;

--- a/client/src/types/label.ts
+++ b/client/src/types/label.ts
@@ -75,11 +75,18 @@ export interface PowerStatus {
   connected: boolean;
 }
 
+export interface BatchRow {
+  // Stable id so React keys survive row reordering/removal. Internal only —
+  // stripped on export, regenerated on import.
+  id: string;
+  values: Record<string, string>;
+}
+
 export interface BatchState {
   enabled: boolean;
   copies: number;
   pauseTime: number;
-  rows: Record<string, string>[];
+  rows: BatchRow[];
   selectedRowIndex: number | null;
 }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -28,13 +28,14 @@ A single Zustand store (`state/useLabelStore.ts`) holds all application state:
 
 ```
 {
-  widgets: LabelWidget[]          # Ordered list of text/QR/barcode/image widgets
-  settings: LabelSettings         # Tape size, margins, justify, colors, printerId
+  widgets: LabelWidget[]           # Ordered list of text/QR/barcode/image widgets
+  settings: LabelSettings          # Tape size, margins, justify, colors, printerId
   availablePrinters: PrinterInfo[] # List of detected printers (real + virtual)
+  batch: BatchState                # Batch print config: copies, pause, variable rows
 }
 ```
 
-The store exposes actions for widget CRUD (`addTextWidget`, `removeWidget`, `updateWidget`), settings updates (`updateSettings`), and printer management (`setAvailablePrinters`). All components subscribe to the store via selectors, so changes automatically trigger re-renders.
+The store exposes actions for widget CRUD (`addTextWidget`, `removeWidget`, `updateWidget`), settings updates (`updateSettings`), printer management (`setAvailablePrinters`), and batch management (`updateBatch`, `setBatchRow`, `addBatchRow`, `removeBatchRow`). All components subscribe to the store via selectors, so changes automatically trigger re-renders.
 
 ### Component Tree
 
@@ -47,8 +48,9 @@ App
       BarcodeWidgetEditor   # Content, type dropdown, show-text toggle
       ImageWidgetEditor     # Thumbnail, filename, replace button
   AddWidgetMenu             # + Text / + QR / + Barcode / + Image buttons
-  PrintButton               # Print trigger with loading/success/error states
-  SaveLoadButtons           # Save/load label JSON files
+  PrintButton               # Print trigger with loading/success/error states; batch mode
+  SaveLoadButtons           # Save/load label JSON files (v2 format with batch data)
+  BatchPanel                # Batch print config: copies, pause, variable table
   SettingsBar               # Tape size, margin, min-length, justify, colors, printer selector
   LabelPreview              # Server-rendered preview image with debounced fetching
 ```
@@ -56,6 +58,8 @@ App
 ### Server-Side Preview
 
 The preview updates on every state change with a 300ms debounce. The `LabelPreview` component calls `POST /api/preview` with the current widgets and settings, and displays the returned PNG image. An `AbortController` cancels in-flight requests when state changes again, and previous object URLs are revoked to prevent memory leaks. The preview is pixel-perfect because it uses the same labelle render engines as printing.
+
+When batch mode is active and a row is selected, `LabelPreview` substitutes variables before sending to the server, so the preview shows the resolved content for that row.
 
 ### Multi-Printer UI
 
@@ -65,6 +69,20 @@ The app fetches available printers on load via `GET /api/printers`. If multiple 
 - Refresh button to re-scan USB devices
 
 The selected `printerId` is stored in `settings` and sent with print requests.
+
+### Batch Print
+
+The batch print feature allows printing multiple labels with variable content (e.g. name badges, asset tags).
+
+**Variable syntax:** `:varname:` in text, QR, or barcode widget content fields. Variables are auto-detected via regex in `lib/variables.ts` using `detectVariables()`, which runs in components via `useMemo` (derived, not stored).
+
+**`BatchPanel`** is a collapsible `<details>` panel that shows:
+- Copies per row and pause time between prints
+- An auto-detected variable table based on current widget content
+- Editable rows; clicking a row selects it for preview
+- Helper text when no variables are detected
+
+**`PrintButton`** switches to batch mode when `batch.enabled` is true: shows "Batch Print (N labels)", streams progress from the server, and offers a cancel button during printing.
 
 ### Type Definitions
 
@@ -76,6 +94,7 @@ All shared types live in `types/label.ts`:
 - `ImageWidget` -- filename (server-side reference from upload)
 - `LabelSettings` -- tapeSizeMm, marginPx, minLengthMm, justify, foregroundColor, backgroundColor, showMargins, printerId
 - `PrinterInfo` -- id, name, vendorProductId, serialNumber
+- `BatchState` -- enabled, copies, pauseTime, rows (variable value maps), selectedRowIndex
 - Union type `LabelWidget = TextWidget | QrWidget | BarcodeWidget | ImageWidget`
 
 ### Constants
@@ -145,7 +164,7 @@ POST /api/print
         -> _build_render_engines(widgets)
         -> HorizontallyCombinedRenderEngine
         -> PrintPayloadRenderEngine
-        -> DymoLabeler.print(bitmap)  # Send to USB
+        -> DymoLabeler.print(bitmap)          # Send to USB
   <- { status, message }
 
 POST /api/preview
@@ -156,6 +175,20 @@ POST /api/preview
       -> PrintPreviewRenderEngine
       -> PNG bytes via PIL
   <- image/png
+
+POST /api/batch-print (SSE streaming)
+  -> app.py (api_batch_print)
+    -> For each row × copies:
+      -> _substitute_widgets(widgets, row)    # Replace :varname: placeholders
+      -> label_builder.print_label(...)       # Print one label
+      -> SSE event: printing/printed
+    -> Check cancellation flag between prints (during pause sleep)
+  <- SSE events: started, printing, printed, done/cancelled/error
+
+POST /api/batch-print/cancel
+  -> Sets cancelled flag for the running job
+  <- { status: "ok" }
+
 GET /api/health
   -> app.py (api_health)
     -> Read version from package.json
@@ -195,6 +228,8 @@ Settings like `marginPx`, `minLengthMm`, `justify`, `tapeSizeMm`, `foregroundCol
 - `GET /api/printers` — Scans USB devices + loads virtual printer config, returns combined list
 - `POST /api/print` — Validates request, extracts printerId, calls `print_label()`, returns JSON status
 - `POST /api/preview` — Validates request, calls `preview_label()`, returns PNG bytes
+- `POST /api/batch-print` — SSE streaming endpoint: substitutes variables per row, prints each label, streams progress events. Only one batch job can run at a time (409 if another is active). Cancellation checked between prints during pause sleep.
+- `POST /api/batch-print/cancel` — sets cancelled flag for a running batch job by jobId
 - `POST /api/upload-image` — Accepts multipart file upload, saves with UUID filename, returns `{ filename }`
 - `GET /api/uploads/<filename>` — Serves uploaded images (used by the editor thumbnail)
 - Static file serving from `dist-client/` with SPA fallback to `index.html`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -84,6 +84,10 @@ The batch print feature allows printing multiple labels with variable content (e
 
 **`PrintButton`** switches to batch mode when `batch.enabled` is true: shows "Batch Print (N labels)", streams progress from the server, and offers a cancel button during printing.
 
+**Print order:** row-major. With N rows and C copies the printer outputs `row1 × C, row2 × C, …` so each label's copies stay together — this matches the common "N copies of each" case where users tear off a stack per recipient. Copy-major ordering (`row1 row2 … rowN` repeated C times) is not currently supported.
+
+**Variable rename heuristic:** when a `updateWidget` edit removes one variable from a widget and adds another, the store treats it as a rename — batch row values follow the new name, and any other widgets referencing the old name are rewritten. The heuristic is set-diff over the widget's variables and has a known limitation: keystroke-by-keystroke typing in a real `<input>` (e.g. `:name:` → `:names` → `:names:`) produces an intermediate state with no closing colon, where the regex sees a pure removal followed later by a pure addition. The row value for `name` orphans in that case. In practice users edit via select-and-replace or paste, which works correctly; orphaned values reappear if the original name is typed back.
+
 ### Type Definitions
 
 All shared types live in `types/label.ts`:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labelle-web",
-  "version": "1.5.3",
+  "version": "1.6.0-dev",
   "private": true,
   "description": "Web interface for labelle DYMO label printers",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labelle-web",
-  "version": "1.6.0-dev",
+  "version": "1.6.0",
   "private": true,
   "description": "Web interface for labelle DYMO label printers",
   "scripts": {

--- a/server/app.py
+++ b/server/app.py
@@ -300,14 +300,15 @@ def api_batch_print():
             ),
         ), 400
 
-    # Only one batch job at a time. Completed jobs are popped in `finally`
-    # below, so a non-empty dict means a job is in flight.
+    # Fast 409 if a job is already running. The actual slot acquisition is
+    # deferred to the start of the generator below so the entry's lifetime
+    # is tied to iteration — if the client aborts before reading any of the
+    # response body, the slot is never inserted and we don't leak it.
     with _batch_lock:
         if _batch_jobs:
             return jsonify(status="error", message="Another batch job is already running"), 409
 
-        job_id = uuid.uuid4().hex
-        _batch_jobs[job_id] = {"cancelled": False}
+    job_id = uuid.uuid4().hex
 
     # Build print list: each row × copies
     print_list = []
@@ -316,6 +317,16 @@ def api_batch_print():
             print_list.append(row)
 
     def generate():
+        # Acquire the slot at the start of iteration. Closes a tiny race
+        # window where two near-simultaneous requests both pass the route
+        # check above; the loser surfaces the same message as an SSE error
+        # event so the client's existing error handling fires.
+        with _batch_lock:
+            if _batch_jobs:
+                yield f"data: {json.dumps({'event': 'error', 'message': 'Another batch job is already running'})}\n\n"
+                return
+            _batch_jobs[job_id] = {"cancelled": False}
+
         try:
             yield f"data: {json.dumps({'event': 'started', 'jobId': job_id, 'total': total})}\n\n"
 

--- a/server/app.py
+++ b/server/app.py
@@ -59,7 +59,7 @@ _batch_lock = threading.Lock()
 MAX_BATCH_COPIES = 999
 MAX_BATCH_ROWS = 1000
 MAX_BATCH_TOTAL = 10000
-MAX_BATCH_PAUSE_SECONDS = 60.0
+MAX_BATCH_PAUSE_SECONDS = 60
 # Cap on total pause time (total labels × pause). Individual caps don't bound
 # the product — 10000 × 60s would be ~7 days holding the print slot — so the
 # combined wall-clock budget caps that out at 8h.
@@ -279,7 +279,7 @@ def api_batch_print():
     if pause_time < 0 or pause_time > MAX_BATCH_PAUSE_SECONDS:
         return jsonify(
             status="error",
-            message=f"pauseTime must be between 0 and {MAX_BATCH_PAUSE_SECONDS:g} seconds",
+            message=f"pauseTime must be between 0 and {MAX_BATCH_PAUSE_SECONDS} seconds",
         ), 400
 
     # Validate row shape up front so failures surface as clean 400s rather

--- a/server/app.py
+++ b/server/app.py
@@ -1,7 +1,10 @@
+import copy
 import json
 import os
+import re
 import subprocess
 import tempfile
+import threading
 import time
 import traceback
 import uuid
@@ -10,7 +13,7 @@ from dotenv import load_dotenv
 
 load_dotenv(os.path.join(os.path.dirname(__file__), "..", ".env"))
 
-from flask import Flask, jsonify, request, send_from_directory
+from flask import Flask, Response, jsonify, request, send_from_directory
 from flask_cors import CORS
 from werkzeug.utils import secure_filename
 
@@ -34,13 +37,23 @@ _POWER_SAVE_IGNORED_PREFIXES = ("/api/power/",)
 # Routes that need the printer to be powered on. The before_request
 # hook will block on a power-on for these if the saver has turned the
 # port off.
-_PRINTER_USING_PATHS = ("/api/print", "/api/preview", "/api/printers", "/api/upload-image")
+_PRINTER_USING_PATHS = (
+    "/api/print",
+    "/api/preview",
+    "/api/printers",
+    "/api/upload-image",
+    "/api/batch-print",
+)
 
 app = Flask(__name__, static_folder=None)
 CORS(app)
 
 DIST_DIR = os.path.join(os.path.dirname(__file__), "dist-client")
 UPLOAD_DIR = tempfile.mkdtemp(prefix="labelle-uploads-")
+
+# Batch job tracking
+_batch_jobs: dict[str, dict] = {}
+_batch_lock = threading.Lock()
 
 
 @app.before_request
@@ -196,6 +209,111 @@ def api_power_off():
     except _POWER_ERRORS as e:
         return _power_error_response(e)
     return jsonify(status="success", hub=hub, port=port_num, **status)
+
+
+def _substitute_widgets(widgets, values):
+    """Replace :varname: placeholders in widget text/content fields."""
+    result = copy.deepcopy(widgets)
+    pattern = re.compile(r":([a-zA-Z_]\w*):")
+    for widget in result:
+        for field in ("text", "content"):
+            if field in widget and isinstance(widget[field], str):
+                widget[field] = pattern.sub(
+                    lambda m: values.get(m.group(1), m.group(0)), widget[field]
+                )
+    return result
+
+
+@app.route("/api/batch-print", methods=["POST"])
+def api_batch_print():
+    data = request.get_json(silent=True) or {}
+    widgets = data.get("widgets")
+    settings = data.get("settings", {})
+    printer_id = settings.get("printerId")
+    rows = data.get("rows", [])
+    copies = max(1, int(data.get("copies", 1)))
+    pause_time = max(0.0, float(data.get("pauseTime", 0)))
+
+    if not widgets or not isinstance(widgets, list) or len(widgets) == 0:
+        return jsonify(status="error", message="No widgets provided"), 400
+    if not rows or not isinstance(rows, list):
+        return jsonify(status="error", message="No rows provided"), 400
+
+    # Only one batch job at a time
+    with _batch_lock:
+        running = [j for j in _batch_jobs.values() if not j.get("done")]
+        if running:
+            return jsonify(status="error", message="Another batch job is already running"), 409
+
+        job_id = uuid.uuid4().hex
+        _batch_jobs[job_id] = {"cancelled": False, "done": False}
+
+    # Build print list: each row × copies
+    print_list = []
+    for row in rows:
+        for _ in range(copies):
+            print_list.append(row)
+
+    total = len(print_list)
+
+    def generate():
+        try:
+            yield f"data: {json.dumps({'event': 'started', 'jobId': job_id, 'total': total})}\n\n"
+
+            for idx, row_values in enumerate(print_list):
+                job = _batch_jobs.get(job_id, {})
+                if job.get("cancelled"):
+                    yield f"data: {json.dumps({'event': 'cancelled', 'printed': idx})}\n\n"
+                    return
+
+                yield f"data: {json.dumps({'event': 'printing', 'index': idx, 'total': total})}\n\n"
+
+                # Keep the idle timer happy while a long batch runs — the
+                # initial before_request fires once, but the SSE stream
+                # outlives it.
+                power_save.record_activity()
+
+                substituted = _substitute_widgets(widgets, row_values)
+                try:
+                    print_label(substituted, settings, upload_dir=UPLOAD_DIR, printer_id=printer_id)
+                except Exception as e:
+                    traceback.print_exc()
+                    yield f"data: {json.dumps({'event': 'error', 'index': idx, 'message': str(e)})}\n\n"
+                    return
+
+                yield f"data: {json.dumps({'event': 'printed', 'index': idx, 'total': total})}\n\n"
+
+                # Pause between prints (except after last)
+                if pause_time > 0 and idx < total - 1:
+                    elapsed = 0.0
+                    while elapsed < pause_time:
+                        if _batch_jobs.get(job_id, {}).get("cancelled"):
+                            yield f"data: {json.dumps({'event': 'cancelled', 'printed': idx + 1})}\n\n"
+                            return
+                        time.sleep(min(0.1, pause_time - elapsed))
+                        elapsed += 0.1
+
+            yield f"data: {json.dumps({'event': 'done', 'total': total})}\n\n"
+        finally:
+            with _batch_lock:
+                if job_id in _batch_jobs:
+                    _batch_jobs[job_id]["done"] = True
+
+    return Response(generate(), mimetype="text/event-stream")
+
+
+@app.route("/api/batch-print/cancel", methods=["POST"])
+def api_batch_cancel():
+    data = request.get_json(silent=True) or {}
+    job_id = data.get("jobId", "")
+
+    with _batch_lock:
+        job = _batch_jobs.get(job_id)
+        if not job:
+            return jsonify(status="error", message="Job not found"), 404
+        job["cancelled"] = True
+
+    return jsonify(status="ok")
 
 
 def _build_info() -> dict:

--- a/server/app.py
+++ b/server/app.py
@@ -254,8 +254,16 @@ def api_batch_print():
     except (TypeError, ValueError):
         return jsonify(status="error", message="copies and pauseTime must be numeric"), 400
 
-    copies = max(1, min(MAX_BATCH_COPIES, copies))
-    pause_time = max(0.0, min(MAX_BATCH_PAUSE_SECONDS, pause_time))
+    if copies < 1 or copies > MAX_BATCH_COPIES:
+        return jsonify(
+            status="error",
+            message=f"copies must be between 1 and {MAX_BATCH_COPIES}",
+        ), 400
+    if pause_time < 0 or pause_time > MAX_BATCH_PAUSE_SECONDS:
+        return jsonify(
+            status="error",
+            message=f"pauseTime must be between 0 and {MAX_BATCH_PAUSE_SECONDS} seconds",
+        ), 400
 
     if not widgets or not isinstance(widgets, list) or len(widgets) == 0:
         return jsonify(status="error", message="No widgets provided"), 400
@@ -292,14 +300,14 @@ def api_batch_print():
             ),
         ), 400
 
-    # Only one batch job at a time
+    # Only one batch job at a time. Completed jobs are popped in `finally`
+    # below, so a non-empty dict means a job is in flight.
     with _batch_lock:
-        running = [j for j in _batch_jobs.values() if not j.get("done")]
-        if running:
+        if _batch_jobs:
             return jsonify(status="error", message="Another batch job is already running"), 409
 
         job_id = uuid.uuid4().hex
-        _batch_jobs[job_id] = {"cancelled": False, "done": False}
+        _batch_jobs[job_id] = {"cancelled": False}
 
     # Build print list: each row × copies
     print_list = []

--- a/server/app.py
+++ b/server/app.py
@@ -310,15 +310,21 @@ def api_batch_print():
             ),
         ), 400
 
-    # Fast 409 if a job is already running. The actual slot acquisition is
-    # deferred to the start of the generator below so the entry's lifetime
-    # is tied to iteration — if the client aborts before reading any of the
-    # response body, the slot is never inserted and we don't leak it.
+    # Reserve the slot atomically here so concurrent requests get a
+    # consistent HTTP 409 + JSON error (instead of one client racing past
+    # the check and finding out via an SSE error frame later). Cleanup is
+    # registered on the Response via call_on_close so the slot is released
+    # even if the generator never iterates (e.g. client aborts before
+    # reading the body).
+    job_id = uuid.uuid4().hex
     with _batch_lock:
         if _batch_jobs:
             return jsonify(status="error", message="Another batch job is already running"), 409
+        _batch_jobs[job_id] = {"cancelled": False}
 
-    job_id = uuid.uuid4().hex
+    def _release_slot():
+        with _batch_lock:
+            _batch_jobs.pop(job_id, None)
 
     # Build print list: each row × copies
     print_list = []
@@ -327,16 +333,6 @@ def api_batch_print():
             print_list.append(row)
 
     def generate():
-        # Acquire the slot at the start of iteration. Closes a tiny race
-        # window where two near-simultaneous requests both pass the route
-        # check above; the loser surfaces the same message as an SSE error
-        # event so the client's existing error handling fires.
-        with _batch_lock:
-            if _batch_jobs:
-                yield f"data: {json.dumps({'event': 'error', 'message': 'Another batch job is already running'})}\n\n"
-                return
-            _batch_jobs[job_id] = {"cancelled": False}
-
         try:
             yield f"data: {json.dumps({'event': 'started', 'jobId': job_id, 'total': total})}\n\n"
 
@@ -384,15 +380,17 @@ def api_batch_print():
 
             yield f"data: {json.dumps({'event': 'done', 'total': total})}\n\n"
         finally:
-            # Drop the entry entirely so _batch_jobs doesn't grow unbounded.
-            with _batch_lock:
-                _batch_jobs.pop(job_id, None)
+            _release_slot()
 
     response = Response(generate(), mimetype="text/event-stream")
     # Disable proxy/server buffering so progress events stream to the client
     # in real time instead of arriving in one chunk at the end.
     response.headers["Cache-Control"] = "no-cache"
     response.headers["X-Accel-Buffering"] = "no"
+    # Defence-in-depth cleanup: if the WSGI layer closes the response before
+    # generate() ever iterates (e.g. client aborts pre-iteration), this fires
+    # and releases the slot. Both paths are idempotent via pop(default=None).
+    response.call_on_close(_release_slot)
     return response
 
 

--- a/server/app.py
+++ b/server/app.py
@@ -61,6 +61,10 @@ MAX_BATCH_COPIES = 999
 MAX_BATCH_ROWS = 1000
 MAX_BATCH_TOTAL = 10000
 MAX_BATCH_PAUSE_SECONDS = 60.0
+# Cap on total pause time (total labels × pause). Individual caps don't bound
+# the product — 10000 × 60s would be ~7 days holding the print slot — so the
+# combined wall-clock budget caps that out at 8h.
+MAX_BATCH_DURATION_SECONDS = 8 * 3600
 
 
 @app.before_request
@@ -275,6 +279,17 @@ def api_batch_print():
         return jsonify(
             status="error",
             message=f"Batch too large: {total} labels (max {MAX_BATCH_TOTAL})",
+        ), 400
+
+    pause_budget = total * pause_time
+    if pause_budget > MAX_BATCH_DURATION_SECONDS:
+        return jsonify(
+            status="error",
+            message=(
+                f"Batch pause budget too long: {pause_budget:.0f}s "
+                f"(max {MAX_BATCH_DURATION_SECONDS}s = "
+                f"{MAX_BATCH_DURATION_SECONDS // 3600}h)"
+            ),
         ), 400
 
     # Only one batch job at a time

--- a/server/app.py
+++ b/server/app.py
@@ -214,7 +214,7 @@ def api_power_off():
 def _substitute_widgets(widgets, values):
     """Replace :varname: placeholders in widget text/content fields."""
     result = copy.deepcopy(widgets)
-    pattern = re.compile(r":([a-zA-Z_]\w*):")
+    pattern = re.compile(r":(\w+):")
     for widget in result:
         for field in ("text", "content"):
             if field in widget and isinstance(widget[field], str):

--- a/server/app.py
+++ b/server/app.py
@@ -320,6 +320,11 @@ def api_batch_print():
             yield f"data: {json.dumps({'event': 'started', 'jobId': job_id, 'total': total})}\n\n"
 
             for idx, row_values in enumerate(print_list):
+                # Lockless read of the cancellation flag is intentional:
+                # dict.get and single-field reads are atomic under CPython's
+                # GIL, and this runs on every iteration. Writes (in the
+                # cancel endpoint) take _batch_lock to serialize against
+                # other writers, but readers don't need it.
                 job = _batch_jobs.get(job_id, {})
                 if job.get("cancelled"):
                     yield f"data: {json.dumps({'event': 'cancelled', 'printed': idx})}\n\n"

--- a/server/app.py
+++ b/server/app.py
@@ -55,6 +55,13 @@ UPLOAD_DIR = tempfile.mkdtemp(prefix="labelle-uploads-")
 _batch_jobs: dict[str, dict] = {}
 _batch_lock = threading.Lock()
 
+# Caps for batch requests. Untrusted JSON otherwise; without these a client
+# could tie up the printer indefinitely and lock out every other batch run.
+MAX_BATCH_COPIES = 999
+MAX_BATCH_ROWS = 1000
+MAX_BATCH_TOTAL = 10000
+MAX_BATCH_PAUSE_SECONDS = 60.0
+
 
 @app.before_request
 def _track_activity_and_wake_printer():
@@ -231,13 +238,29 @@ def api_batch_print():
     settings = data.get("settings", {})
     printer_id = settings.get("printerId")
     rows = data.get("rows", [])
-    copies = max(1, int(data.get("copies", 1)))
-    pause_time = max(0.0, float(data.get("pauseTime", 0)))
+
+    try:
+        copies = int(data.get("copies", 1))
+        pause_time = float(data.get("pauseTime", 0))
+    except (TypeError, ValueError):
+        return jsonify(status="error", message="copies and pauseTime must be numeric"), 400
+
+    copies = max(1, min(MAX_BATCH_COPIES, copies))
+    pause_time = max(0.0, min(MAX_BATCH_PAUSE_SECONDS, pause_time))
 
     if not widgets or not isinstance(widgets, list) or len(widgets) == 0:
         return jsonify(status="error", message="No widgets provided"), 400
     if not rows or not isinstance(rows, list):
         return jsonify(status="error", message="No rows provided"), 400
+    if len(rows) > MAX_BATCH_ROWS:
+        return jsonify(status="error", message=f"Too many rows (max {MAX_BATCH_ROWS})"), 400
+
+    total = len(rows) * copies
+    if total > MAX_BATCH_TOTAL:
+        return jsonify(
+            status="error",
+            message=f"Batch too large: {total} labels (max {MAX_BATCH_TOTAL})",
+        ), 400
 
     # Only one batch job at a time
     with _batch_lock:
@@ -253,8 +276,6 @@ def api_batch_print():
     for row in rows:
         for _ in range(copies):
             print_list.append(row)
-
-    total = len(print_list)
 
     def generate():
         try:
@@ -283,23 +304,32 @@ def api_batch_print():
 
                 yield f"data: {json.dumps({'event': 'printed', 'index': idx, 'total': total})}\n\n"
 
-                # Pause between prints (except after last)
+                # Pause between prints (except after last). Use monotonic
+                # deadline so the actual elapsed time matches pause_time
+                # regardless of clock skew or fractional sleep durations.
                 if pause_time > 0 and idx < total - 1:
-                    elapsed = 0.0
-                    while elapsed < pause_time:
+                    deadline = time.monotonic() + pause_time
+                    while True:
+                        remaining = deadline - time.monotonic()
+                        if remaining <= 0:
+                            break
                         if _batch_jobs.get(job_id, {}).get("cancelled"):
                             yield f"data: {json.dumps({'event': 'cancelled', 'printed': idx + 1})}\n\n"
                             return
-                        time.sleep(min(0.1, pause_time - elapsed))
-                        elapsed += 0.1
+                        time.sleep(min(0.1, remaining))
 
             yield f"data: {json.dumps({'event': 'done', 'total': total})}\n\n"
         finally:
+            # Drop the entry entirely so _batch_jobs doesn't grow unbounded.
             with _batch_lock:
-                if job_id in _batch_jobs:
-                    _batch_jobs[job_id]["done"] = True
+                _batch_jobs.pop(job_id, None)
 
-    return Response(generate(), mimetype="text/event-stream")
+    response = Response(generate(), mimetype="text/event-stream")
+    # Disable proxy/server buffering so progress events stream to the client
+    # in real time instead of arriving in one chunk at the end.
+    response.headers["Cache-Control"] = "no-cache"
+    response.headers["X-Accel-Buffering"] = "no"
+    return response
 
 
 @app.route("/api/batch-print/cancel", methods=["POST"])

--- a/server/app.py
+++ b/server/app.py
@@ -1,4 +1,5 @@
 import json
+import math
 import os
 import re
 import subprocess
@@ -262,14 +263,28 @@ def api_batch_print():
     if len(rows) > MAX_BATCH_ROWS:
         return jsonify(status="error", message=f"Too many rows (max {MAX_BATCH_ROWS})"), 400
 
+    raw_copies = data.get("copies", 1)
+    # Reject bool (True/False are ints in Python) and non-integer numerics
+    # like 1.9 — silent truncation is surprising for API consumers.
+    if isinstance(raw_copies, bool):
+        return jsonify(status="error", message="copies must be an integer"), 400
     try:
-        copies = int(data.get("copies", 1))
+        copies_float = float(raw_copies)
     except (TypeError, ValueError):
         return jsonify(status="error", message="copies must be numeric"), 400
+    if not math.isfinite(copies_float) or not copies_float.is_integer():
+        return jsonify(status="error", message="copies must be a finite integer"), 400
+    copies = int(copies_float)
+
+    raw_pause = data.get("pauseTime", 0)
+    if isinstance(raw_pause, bool):
+        return jsonify(status="error", message="pauseTime must be a number"), 400
     try:
-        pause_time = float(data.get("pauseTime", 0))
+        pause_time = float(raw_pause)
     except (TypeError, ValueError):
         return jsonify(status="error", message="pauseTime must be numeric"), 400
+    if not math.isfinite(pause_time):
+        return jsonify(status="error", message="pauseTime must be a finite number"), 400
 
     if copies < 1 or copies > MAX_BATCH_COPIES:
         return jsonify(
@@ -285,10 +300,11 @@ def api_batch_print():
     # Validate row shape up front so failures surface as clean 400s rather
     # than blowing up the SSE stream mid-print. Coerce values to strings so
     # `{name: 42}` becomes `{name: "42"}` instead of crashing re.sub later.
+    # Row indices in the error message are 1-based to match the BatchPanel UI.
     normalised_rows = []
     for i, row in enumerate(rows):
         if not isinstance(row, dict):
-            return jsonify(status="error", message=f"Row {i} must be an object"), 400
+            return jsonify(status="error", message=f"Row {i + 1} must be an object"), 400
         normalised_rows.append({str(k): str(v) for k, v in row.items()})
     rows = normalised_rows
 

--- a/server/app.py
+++ b/server/app.py
@@ -264,9 +264,12 @@ def api_batch_print():
 
     try:
         copies = int(data.get("copies", 1))
+    except (TypeError, ValueError):
+        return jsonify(status="error", message="copies must be numeric"), 400
+    try:
         pause_time = float(data.get("pauseTime", 0))
     except (TypeError, ValueError):
-        return jsonify(status="error", message="copies and pauseTime must be numeric"), 400
+        return jsonify(status="error", message="pauseTime must be numeric"), 400
 
     if copies < 1 or copies > MAX_BATCH_COPIES:
         return jsonify(

--- a/server/app.py
+++ b/server/app.py
@@ -406,6 +406,9 @@ def api_batch_print():
     # Defence-in-depth cleanup: if the WSGI layer closes the response before
     # generate() ever iterates (e.g. client aborts pre-iteration), this fires
     # and releases the slot. Both paths are idempotent via pop(default=None).
+    # On normal completion, the generator's finally runs first and pops; the
+    # trailing call_on_close is a no-op. _release_slot closes over this job's
+    # id, so a new batch submitted between the two events isn't affected.
     response.call_on_close(_release_slot)
     return response
 
@@ -413,7 +416,10 @@ def api_batch_print():
 @app.route("/api/batch-print/cancel", methods=["POST"])
 def api_batch_cancel():
     data = request.get_json(silent=True) or {}
-    job_id = data.get("jobId", "")
+    job_id = data.get("jobId")
+
+    if not job_id or not isinstance(job_id, str):
+        return jsonify(status="error", message="jobId is required"), 400
 
     with _batch_lock:
         job = _batch_jobs.get(job_id)

--- a/server/app.py
+++ b/server/app.py
@@ -345,7 +345,19 @@ def api_batch_print():
     # registered on the Response via call_on_close so the slot is released
     # even if the generator never iterates (e.g. client aborts before
     # reading the body).
-    job_id = uuid.uuid4().hex
+    #
+    # The client may provide its own jobId so it can request cancellation
+    # without waiting for the `started` SSE event (closes an unmount-race
+    # window). Server falls back to its own uuid if the client didn't
+    # supply one. Accepted format: 8-64 chars of [a-zA-Z0-9_-].
+    raw_job_id = data.get("jobId")
+    if raw_job_id is not None:
+        if not isinstance(raw_job_id, str) or not re.fullmatch(r"[a-zA-Z0-9_-]{8,64}", raw_job_id):
+            return jsonify(status="error", message="jobId must be 8-64 chars of [a-zA-Z0-9_-]"), 400
+        job_id = raw_job_id
+    else:
+        job_id = uuid.uuid4().hex
+
     with _batch_lock:
         if _batch_jobs:
             return jsonify(status="error", message="Another batch job is already running"), 409

--- a/server/app.py
+++ b/server/app.py
@@ -248,6 +248,15 @@ def api_batch_print():
     printer_id = settings.get("printerId")
     rows = data.get("rows", [])
 
+    # Presence checks first: a user with both missing widgets and bad
+    # copies should hear about the more fundamental problem first.
+    if not widgets or not isinstance(widgets, list) or len(widgets) == 0:
+        return jsonify(status="error", message="No widgets provided"), 400
+    if not rows or not isinstance(rows, list):
+        return jsonify(status="error", message="No rows provided"), 400
+    if len(rows) > MAX_BATCH_ROWS:
+        return jsonify(status="error", message=f"Too many rows (max {MAX_BATCH_ROWS})"), 400
+
     try:
         copies = int(data.get("copies", 1))
         pause_time = float(data.get("pauseTime", 0))
@@ -262,15 +271,8 @@ def api_batch_print():
     if pause_time < 0 or pause_time > MAX_BATCH_PAUSE_SECONDS:
         return jsonify(
             status="error",
-            message=f"pauseTime must be between 0 and {MAX_BATCH_PAUSE_SECONDS} seconds",
+            message=f"pauseTime must be between 0 and {MAX_BATCH_PAUSE_SECONDS:g} seconds",
         ), 400
-
-    if not widgets or not isinstance(widgets, list) or len(widgets) == 0:
-        return jsonify(status="error", message="No widgets provided"), 400
-    if not rows or not isinstance(rows, list):
-        return jsonify(status="error", message="No rows provided"), 400
-    if len(rows) > MAX_BATCH_ROWS:
-        return jsonify(status="error", message=f"Too many rows (max {MAX_BATCH_ROWS})"), 400
 
     # Validate row shape up front so failures surface as clean 400s rather
     # than blowing up the SSE stream mid-print. Coerce values to strings so

--- a/server/app.py
+++ b/server/app.py
@@ -219,14 +219,19 @@ def api_power_off():
 
 
 def _substitute_widgets(widgets, values):
-    """Replace :varname: placeholders in widget text/content fields."""
+    """Replace :varname: placeholders in widget text/content fields.
+
+    Values are coerced to str so a stray non-string slipping past validation
+    doesn't crash re.sub's callback.
+    """
     result = copy.deepcopy(widgets)
     pattern = re.compile(r":(\w+):")
     for widget in result:
         for field in ("text", "content"):
             if field in widget and isinstance(widget[field], str):
                 widget[field] = pattern.sub(
-                    lambda m: values.get(m.group(1), m.group(0)), widget[field]
+                    lambda m: str(values.get(m.group(1), m.group(0))),
+                    widget[field],
                 )
     return result
 
@@ -254,6 +259,16 @@ def api_batch_print():
         return jsonify(status="error", message="No rows provided"), 400
     if len(rows) > MAX_BATCH_ROWS:
         return jsonify(status="error", message=f"Too many rows (max {MAX_BATCH_ROWS})"), 400
+
+    # Validate row shape up front so failures surface as clean 400s rather
+    # than blowing up the SSE stream mid-print. Coerce values to strings so
+    # `{name: 42}` becomes `{name: "42"}` instead of crashing re.sub later.
+    normalised_rows = []
+    for i, row in enumerate(rows):
+        if not isinstance(row, dict):
+            return jsonify(status="error", message=f"Row {i} must be an object"), 400
+        normalised_rows.append({str(k): str(v) for k, v in row.items()})
+    rows = normalised_rows
 
     total = len(rows) * copies
     if total > MAX_BATCH_TOTAL:
@@ -294,8 +309,8 @@ def api_batch_print():
                 # outlives it.
                 power_save.record_activity()
 
-                substituted = _substitute_widgets(widgets, row_values)
                 try:
+                    substituted = _substitute_widgets(widgets, row_values)
                     print_label(substituted, settings, upload_dir=UPLOAD_DIR, printer_id=printer_id)
                 except Exception as e:
                     traceback.print_exc()

--- a/server/app.py
+++ b/server/app.py
@@ -1,4 +1,3 @@
-import copy
 import json
 import os
 import re
@@ -222,21 +221,27 @@ def api_power_off():
     return jsonify(status="success", hub=hub, port=port_num, **status)
 
 
+_VAR_PATTERN = re.compile(r":(\w+):")
+
+
 def _substitute_widgets(widgets, values):
     """Replace :varname: placeholders in widget text/content fields.
 
-    Values are coerced to str so a stray non-string slipping past validation
-    doesn't crash re.sub's callback.
+    Each widget is shallow-copied because only the immutable string fields
+    `text`/`content` are reassigned — deepcopy was wasteful per row × per
+    copy at batch scale. Values are coerced to str so a stray non-string
+    slipping past validation doesn't crash re.sub's callback.
     """
-    result = copy.deepcopy(widgets)
-    pattern = re.compile(r":(\w+):")
-    for widget in result:
+    result = []
+    for widget in widgets:
+        new_widget = dict(widget)
         for field in ("text", "content"):
-            if field in widget and isinstance(widget[field], str):
-                widget[field] = pattern.sub(
+            if isinstance(new_widget.get(field), str):
+                new_widget[field] = _VAR_PATTERN.sub(
                     lambda m: str(values.get(m.group(1), m.group(0))),
-                    widget[field],
+                    new_widget[field],
                 )
+        result.append(new_widget)
     return result
 
 

--- a/server/app.py
+++ b/server/app.py
@@ -36,7 +36,10 @@ _POWER_SAVE_IGNORED_PREFIXES = ("/api/power/",)
 
 # Routes that need the printer to be powered on. The before_request
 # hook will block on a power-on for these if the saver has turned the
-# port off.
+# port off. Membership check uses exact equality (not prefix), so
+# /api/batch-print triggers wake-up but /api/batch-print/cancel
+# deliberately does not — cancelling shouldn't be gated on the
+# printer being awake.
 _PRINTER_USING_PATHS = (
     "/api/print",
     "/api/preview",
@@ -298,14 +301,24 @@ def api_batch_print():
         ), 400
 
     # Validate row shape up front so failures surface as clean 400s rather
-    # than blowing up the SSE stream mid-print. Coerce values to strings so
-    # `{name: 42}` becomes `{name: "42"}` instead of crashing re.sub later.
+    # than blowing up the SSE stream mid-print. Numeric values are coerced
+    # to strings so `{name: 42}` becomes `{name: "42"}`; other non-string
+    # types (None, bool, list, dict) are rejected because str()-ing them
+    # would print surprising literals on the label like "None" or "True".
     # Row indices in the error message are 1-based to match the BatchPanel UI.
     normalised_rows = []
     for i, row in enumerate(rows):
         if not isinstance(row, dict):
             return jsonify(status="error", message=f"Row {i + 1} must be an object"), 400
-        normalised_rows.append({str(k): str(v) for k, v in row.items()})
+        clean: dict[str, str] = {}
+        for k, v in row.items():
+            if isinstance(v, bool) or not isinstance(v, (str, int, float)):
+                return jsonify(
+                    status="error",
+                    message=f"Row {i + 1} field {k!r} must be a string or number",
+                ), 400
+            clean[str(k)] = str(v)
+        normalised_rows.append(clean)
     rows = normalised_rows
 
     total = len(rows) * copies

--- a/server/tests/test_batch.py
+++ b/server/tests/test_batch.py
@@ -83,6 +83,34 @@ class TestBatchPrintValidation:
         assert resp.status_code == 400
         assert "numeric" in resp.json["message"]
 
+    def test_copies_above_max_returns_400(self, client):
+        resp = client.post(
+            "/api/batch-print",
+            data=json.dumps({
+                "widgets": [_widget()],
+                "settings": _settings(),
+                "rows": [{"name": "A"}],
+                "copies": 9999,
+            }),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        assert "copies" in resp.json["message"]
+
+    def test_pause_above_max_returns_400(self, client):
+        resp = client.post(
+            "/api/batch-print",
+            data=json.dumps({
+                "widgets": [_widget()],
+                "settings": _settings(),
+                "rows": [{"name": "A"}],
+                "pauseTime": 600,
+            }),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        assert "pauseTime" in resp.json["message"]
+
     def test_too_many_rows_returns_400(self, client):
         from app import MAX_BATCH_ROWS
 
@@ -281,7 +309,7 @@ class TestBatchPrintConcurrency:
         # Seed a fake in-flight job in the tracker.
         from app import _batch_jobs
 
-        _batch_jobs["fake"] = {"cancelled": False, "done": False}
+        _batch_jobs["fake"] = {"cancelled": False}
 
         resp = client.post(
             "/api/batch-print",
@@ -309,7 +337,7 @@ class TestBatchCancel:
     def test_cancel_sets_flag_on_running_job(self, client):
         from app import _batch_jobs
 
-        _batch_jobs["live"] = {"cancelled": False, "done": False}
+        _batch_jobs["live"] = {"cancelled": False}
         resp = client.post(
             "/api/batch-print/cancel",
             data=json.dumps({"jobId": "live"}),

--- a/server/tests/test_batch.py
+++ b/server/tests/test_batch.py
@@ -129,6 +129,23 @@ class TestBatchPrintValidation:
         assert resp.status_code == 400
         assert "Row 1" in resp.json["message"]
 
+    def test_pause_budget_too_long_returns_400(self, client):
+        # 1000 rows × 1 copy × 60s pause = 60000s ≈ 16.7h, over the 8h cap.
+        rows = [{"name": str(i)} for i in range(1000)]
+        resp = client.post(
+            "/api/batch-print",
+            data=json.dumps({
+                "widgets": [_widget()],
+                "settings": _settings(),
+                "rows": rows,
+                "copies": 1,
+                "pauseTime": 60,
+            }),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        assert "pause budget" in resp.json["message"]
+
     @patch("app.print_label")
     def test_non_string_value_is_coerced(self, mock_print, client):
         # Non-string values shouldn't crash the SSE stream — they get coerced

--- a/server/tests/test_batch.py
+++ b/server/tests/test_batch.py
@@ -116,6 +116,37 @@ class TestBatchPrintValidation:
         assert resp.status_code == 400
         assert "Batch too large" in resp.json["message"]
 
+    def test_non_dict_row_returns_400(self, client):
+        resp = client.post(
+            "/api/batch-print",
+            data=json.dumps({
+                "widgets": [_widget()],
+                "settings": _settings(),
+                "rows": [{"name": "A"}, "not-a-dict"],
+            }),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        assert "Row 1" in resp.json["message"]
+
+    @patch("app.print_label")
+    def test_non_string_value_is_coerced(self, mock_print, client):
+        # Non-string values shouldn't crash the SSE stream — they get coerced
+        # to strings during row validation.
+        resp = client.post(
+            "/api/batch-print",
+            data=json.dumps({
+                "widgets": [_widget()],
+                "settings": _settings(),
+                "rows": [{"name": 42}],
+            }),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        _read_sse(resp)
+        call_widgets = mock_print.call_args_list[0][0][0]
+        assert call_widgets[0]["text"] == "Hello 42"
+
 
 class TestBatchPrintExecution:
     @patch("app.print_label")

--- a/server/tests/test_batch.py
+++ b/server/tests/test_batch.py
@@ -1,6 +1,5 @@
 """Tests for the /api/batch-print and /api/batch-print/cancel endpoints."""
 import json
-import time
 from unittest.mock import patch
 
 import pytest

--- a/server/tests/test_batch.py
+++ b/server/tests/test_batch.py
@@ -84,6 +84,7 @@ class TestBatchPrintValidation:
             content_type="application/json",
         )
         assert resp.status_code == 400
+        assert "copies" in resp.json["message"]
         assert "numeric" in resp.json["message"]
 
     def test_copies_above_max_returns_400(self, client):

--- a/server/tests/test_batch.py
+++ b/server/tests/test_batch.py
@@ -1,0 +1,298 @@
+"""Tests for the /api/batch-print and /api/batch-print/cancel endpoints."""
+import json
+import time
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def client(virtual_printer_env):
+    from app import app
+
+    app.config["TESTING"] = True
+    # Drain any leftover jobs from prior tests (the module-level dict is
+    # process-wide and tests share it).
+    from app import _batch_jobs
+
+    _batch_jobs.clear()
+    with app.test_client() as client:
+        yield client
+
+
+def _settings():
+    return {
+        "tapeSizeMm": 12,
+        "marginPx": 56,
+        "minLengthMm": 0,
+        "justify": "center",
+        "foregroundColor": "black",
+        "backgroundColor": "white",
+        "showMargins": False,
+        "printerId": "virtual:Test_Printer",
+    }
+
+
+def _widget():
+    return {"type": "text", "text": "Hello :name:", "id": "1"}
+
+
+def _read_sse(resp):
+    """Drain an SSE response into a list of event dicts."""
+    events = []
+    buffer = ""
+    for chunk in resp.response:
+        buffer += chunk.decode()
+        while "\n\n" in buffer:
+            frame, buffer = buffer.split("\n\n", 1)
+            for line in frame.split("\n"):
+                if line.startswith("data: "):
+                    events.append(json.loads(line[6:]))
+    return events
+
+
+class TestBatchPrintValidation:
+    def test_missing_widgets_returns_400(self, client):
+        resp = client.post(
+            "/api/batch-print",
+            data=json.dumps({"widgets": [], "settings": _settings(), "rows": [{}]}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        assert resp.json["message"] == "No widgets provided"
+
+    def test_missing_rows_returns_400(self, client):
+        resp = client.post(
+            "/api/batch-print",
+            data=json.dumps({"widgets": [_widget()], "settings": _settings(), "rows": []}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        assert resp.json["message"] == "No rows provided"
+
+    def test_non_numeric_copies_returns_400(self, client):
+        resp = client.post(
+            "/api/batch-print",
+            data=json.dumps({
+                "widgets": [_widget()],
+                "settings": _settings(),
+                "rows": [{"name": "A"}],
+                "copies": "lots",
+            }),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        assert "numeric" in resp.json["message"]
+
+    def test_too_many_rows_returns_400(self, client):
+        from app import MAX_BATCH_ROWS
+
+        rows = [{"name": str(i)} for i in range(MAX_BATCH_ROWS + 1)]
+        resp = client.post(
+            "/api/batch-print",
+            data=json.dumps({
+                "widgets": [_widget()],
+                "settings": _settings(),
+                "rows": rows,
+            }),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        assert "Too many rows" in resp.json["message"]
+
+    def test_too_large_total_returns_400(self, client):
+        # 100 rows × 200 copies = 20000, well over MAX_BATCH_TOTAL=10000
+        rows = [{"name": str(i)} for i in range(100)]
+        resp = client.post(
+            "/api/batch-print",
+            data=json.dumps({
+                "widgets": [_widget()],
+                "settings": _settings(),
+                "rows": rows,
+                "copies": 200,
+            }),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        assert "Batch too large" in resp.json["message"]
+
+
+class TestBatchPrintExecution:
+    @patch("app.print_label")
+    def test_prints_each_row_with_substitution(self, mock_print, client):
+        resp = client.post(
+            "/api/batch-print",
+            data=json.dumps({
+                "widgets": [_widget()],
+                "settings": _settings(),
+                "rows": [{"name": "Alice"}, {"name": "Bob"}],
+            }),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        events = _read_sse(resp)
+        assert events[0]["event"] == "started"
+        assert events[0]["total"] == 2
+        assert events[-1]["event"] == "done"
+        assert mock_print.call_count == 2
+        # First call substituted "Alice"
+        first_call_widgets = mock_print.call_args_list[0][0][0]
+        assert first_call_widgets[0]["text"] == "Hello Alice"
+        # Second call substituted "Bob"
+        second_call_widgets = mock_print.call_args_list[1][0][0]
+        assert second_call_widgets[0]["text"] == "Hello Bob"
+
+    @patch("app.print_label")
+    def test_missing_value_leaves_placeholder_literal(self, mock_print, client):
+        # Rationale: visible "you forgot" indicator. Empty-string values
+        # are substituted as empty (separate behavior).
+        resp = client.post(
+            "/api/batch-print",
+            data=json.dumps({
+                "widgets": [_widget()],
+                "settings": _settings(),
+                "rows": [{}],  # no "name" key at all
+            }),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        _read_sse(resp)
+        call_widgets = mock_print.call_args_list[0][0][0]
+        assert call_widgets[0]["text"] == "Hello :name:"
+
+    @patch("app.print_label")
+    def test_empty_string_value_substitutes_as_empty(self, mock_print, client):
+        resp = client.post(
+            "/api/batch-print",
+            data=json.dumps({
+                "widgets": [_widget()],
+                "settings": _settings(),
+                "rows": [{"name": ""}],
+            }),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        _read_sse(resp)
+        call_widgets = mock_print.call_args_list[0][0][0]
+        assert call_widgets[0]["text"] == "Hello "
+
+    @patch("app.print_label")
+    def test_copies_multiplies_rows(self, mock_print, client):
+        resp = client.post(
+            "/api/batch-print",
+            data=json.dumps({
+                "widgets": [_widget()],
+                "settings": _settings(),
+                "rows": [{"name": "A"}, {"name": "B"}],
+                "copies": 3,
+            }),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        events = _read_sse(resp)
+        assert events[0]["total"] == 6
+        assert mock_print.call_count == 6
+
+    @patch("app.print_label")
+    def test_pops_completed_job_from_tracking(self, mock_print, client):
+        from app import _batch_jobs
+
+        resp = client.post(
+            "/api/batch-print",
+            data=json.dumps({
+                "widgets": [_widget()],
+                "settings": _settings(),
+                "rows": [{"name": "Alice"}],
+            }),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        _read_sse(resp)
+        # The job should be cleared once the stream completes (no memory leak).
+        assert _batch_jobs == {}
+
+
+class TestBatchPrintHeaders:
+    @patch("app.print_label")
+    def test_sse_response_has_anti_buffering_headers(self, mock_print, client):
+        resp = client.post(
+            "/api/batch-print",
+            data=json.dumps({
+                "widgets": [_widget()],
+                "settings": _settings(),
+                "rows": [{"name": "A"}],
+            }),
+            content_type="application/json",
+        )
+        assert resp.headers.get("Cache-Control") == "no-cache"
+        assert resp.headers.get("X-Accel-Buffering") == "no"
+        _read_sse(resp)  # drain
+
+
+class TestBatchPrintConcurrency:
+    def test_returns_409_when_another_job_running(self, client):
+        # Seed a fake in-flight job in the tracker.
+        from app import _batch_jobs
+
+        _batch_jobs["fake"] = {"cancelled": False, "done": False}
+
+        resp = client.post(
+            "/api/batch-print",
+            data=json.dumps({
+                "widgets": [_widget()],
+                "settings": _settings(),
+                "rows": [{"name": "A"}],
+            }),
+            content_type="application/json",
+        )
+        assert resp.status_code == 409
+        assert "already running" in resp.json["message"]
+        _batch_jobs.clear()
+
+
+class TestBatchCancel:
+    def test_cancel_unknown_job_returns_404(self, client):
+        resp = client.post(
+            "/api/batch-print/cancel",
+            data=json.dumps({"jobId": "does-not-exist"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 404
+
+    def test_cancel_sets_flag_on_running_job(self, client):
+        from app import _batch_jobs
+
+        _batch_jobs["live"] = {"cancelled": False, "done": False}
+        resp = client.post(
+            "/api/batch-print/cancel",
+            data=json.dumps({"jobId": "live"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        assert _batch_jobs["live"]["cancelled"] is True
+        _batch_jobs.clear()
+
+    @patch("app.print_label")
+    def test_cancellation_stops_batch_between_prints(self, mock_print, client):
+        # Set the cancelled flag from the first print_label call so the
+        # next iteration's check sees it.
+        from app import _batch_jobs
+
+        def cancel_after_first_call(*args, **kwargs):
+            for job in _batch_jobs.values():
+                job["cancelled"] = True
+
+        mock_print.side_effect = cancel_after_first_call
+        resp = client.post(
+            "/api/batch-print",
+            data=json.dumps({
+                "widgets": [_widget()],
+                "settings": _settings(),
+                "rows": [{"name": "A"}, {"name": "B"}, {"name": "C"}],
+            }),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        events = _read_sse(resp)
+        assert mock_print.call_count == 1
+        assert any(e["event"] == "cancelled" for e in events)

--- a/server/tests/test_batch.py
+++ b/server/tests/test_batch.py
@@ -322,7 +322,6 @@ class TestBatchPrintConcurrency:
         )
         assert resp.status_code == 409
         assert "already running" in resp.json["message"]
-        _batch_jobs.clear()
 
 
 class TestBatchCancel:
@@ -345,7 +344,6 @@ class TestBatchCancel:
         )
         assert resp.status_code == 200
         assert _batch_jobs["live"]["cancelled"] is True
-        _batch_jobs.clear()
 
     @patch("app.print_label")
     def test_cancellation_stops_batch_between_prints(self, mock_print, client):

--- a/server/tests/test_batch.py
+++ b/server/tests/test_batch.py
@@ -115,6 +115,55 @@ class TestBatchPrintValidation:
         assert resp.status_code == 400
         assert "pauseTime" in resp.json["message"]
 
+    def test_non_integer_copies_returns_400(self, client):
+        resp = client.post(
+            "/api/batch-print",
+            data=json.dumps({
+                "widgets": [_widget()],
+                "settings": _settings(),
+                "rows": [{"name": "A"}],
+                "copies": 1.9,
+            }),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        assert "integer" in resp.json["message"]
+
+    def test_bool_copies_returns_400(self, client):
+        resp = client.post(
+            "/api/batch-print",
+            data=json.dumps({
+                "widgets": [_widget()],
+                "settings": _settings(),
+                "rows": [{"name": "A"}],
+                "copies": True,
+            }),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        assert "integer" in resp.json["message"]
+
+    def test_nan_pause_returns_400(self, client):
+        # JSON doesn't allow NaN by default, but Python's json module is
+        # lenient — and `float("nan")` slipped past the comparison checks
+        # before, then crashed time.sleep() mid-batch.
+        resp = client.post(
+            "/api/batch-print",
+            data='{"widgets":[{"type":"text","text":"x","id":"1"}],"settings":{},"rows":[{"name":"A"}],"pauseTime":NaN}',
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        assert "finite" in resp.json["message"]
+
+    def test_inf_pause_returns_400(self, client):
+        resp = client.post(
+            "/api/batch-print",
+            data='{"widgets":[{"type":"text","text":"x","id":"1"}],"settings":{},"rows":[{"name":"A"}],"pauseTime":Infinity}',
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        assert "finite" in resp.json["message"]
+
     def test_too_many_rows_returns_400(self, client):
         from app import MAX_BATCH_ROWS
 
@@ -158,7 +207,8 @@ class TestBatchPrintValidation:
             content_type="application/json",
         )
         assert resp.status_code == 400
-        assert "Row 1" in resp.json["message"]
+        # 1-indexed to match the UI
+        assert "Row 2" in resp.json["message"]
 
     def test_pause_budget_too_long_returns_400(self, client):
         # 1000 rows × 1 copy × 60s pause = 60000s ≈ 16.7h, over the 8h cap.

--- a/server/tests/test_batch.py
+++ b/server/tests/test_batch.py
@@ -228,9 +228,8 @@ class TestBatchPrintValidation:
         assert "pause budget" in resp.json["message"]
 
     @patch("app.print_label")
-    def test_non_string_value_is_coerced(self, mock_print, client):
-        # Non-string values shouldn't crash the SSE stream — they get coerced
-        # to strings during row validation.
+    def test_numeric_value_is_coerced_to_string(self, mock_print, client):
+        # Numbers are stringified for ergonomics — sending {qty: 42} works.
         resp = client.post(
             "/api/batch-print",
             data=json.dumps({
@@ -244,6 +243,47 @@ class TestBatchPrintValidation:
         _read_sse(resp)
         call_widgets = mock_print.call_args_list[0][0][0]
         assert call_widgets[0]["text"] == "Hello 42"
+
+    def test_none_value_is_rejected(self, client):
+        # str(None) = "None" would print as a literal on the label, not what
+        # anyone wants — reject explicitly.
+        resp = client.post(
+            "/api/batch-print",
+            data=json.dumps({
+                "widgets": [_widget()],
+                "settings": _settings(),
+                "rows": [{"name": None}],
+            }),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        assert "string or number" in resp.json["message"]
+
+    def test_bool_value_is_rejected(self, client):
+        resp = client.post(
+            "/api/batch-print",
+            data=json.dumps({
+                "widgets": [_widget()],
+                "settings": _settings(),
+                "rows": [{"name": True}],
+            }),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        assert "string or number" in resp.json["message"]
+
+    def test_list_value_is_rejected(self, client):
+        resp = client.post(
+            "/api/batch-print",
+            data=json.dumps({
+                "widgets": [_widget()],
+                "settings": _settings(),
+                "rows": [{"name": [1, 2]}],
+            }),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        assert "string or number" in resp.json["message"]
 
 
 class TestBatchPrintExecution:

--- a/server/tests/test_batch.py
+++ b/server/tests/test_batch.py
@@ -11,7 +11,10 @@ def client(virtual_printer_env):
 
     app.config["TESTING"] = True
     # Drain any leftover jobs from prior tests (the module-level dict is
-    # process-wide and tests share it).
+    # process-wide and tests share it). Mutating _batch_jobs here and in
+    # individual tests bypasses _batch_lock intentionally — Flask's test
+    # client runs requests serially so there's no concurrency to guard
+    # against. Don't copy this pattern into production code.
     from app import _batch_jobs
 
     _batch_jobs.clear()

--- a/server/tests/test_batch.py
+++ b/server/tests/test_batch.py
@@ -387,6 +387,24 @@ class TestBatchCancel:
         )
         assert resp.status_code == 404
 
+    def test_cancel_missing_jobid_returns_400(self, client):
+        resp = client.post(
+            "/api/batch-print/cancel",
+            data=json.dumps({}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        assert "jobId" in resp.json["message"]
+
+    def test_cancel_empty_jobid_returns_400(self, client):
+        resp = client.post(
+            "/api/batch-print/cancel",
+            data=json.dumps({"jobId": ""}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        assert "jobId" in resp.json["message"]
+
     def test_cancel_sets_flag_on_running_job(self, client):
         from app import _batch_jobs
 


### PR DESCRIPTION
## Summary

Adds batch print mode: print many labels from one template, with `:varname:` placeholders substituted per row.

Batch mode is **implicit** — having any `:varname:` in widget text turns the Print button into "Batch Print (N labels)". No checkbox to forget.

## User-facing features

- **Variable syntax** — `:name:`, `:001:`, `:_foo:` etc. work in text widgets, QR content, and barcode content. Detected automatically.
- **Spreadsheet UI** — columns are detected variables, rows are labels. Click the eye icon on a row to live-preview that row's values in the main preview pane. Click `+ Add Variable` to insert a new placeholder (creates a text widget if none exists). Click `+ Add Row` to add a label.
- **Rename propagates** — editing `:name:` → `:fullname:` in any widget renames it in every other widget that references it, and the row column header (and stored values) follow.
- **Per-job knobs** — Copies (×N per row) and Pause (seconds between prints, intended for tear-off/sort).
- **Live progress** — Print button shows "Printing N/total..." while running, with a Cancel button. Server-Sent Events stream `started`/`printing`/`printed`/`done`/`cancelled`/`error`.
- **Save/load** — batch data round-trips through the existing `.json` label file format.

## Server API

- `POST /api/batch-print` — SSE endpoint. Accepts widgets, settings, rows, copies, pauseTime, and an optional client-supplied jobId. Validates input (numeric ranges, row shape, total label count, total pause budget). Returns 400 on validation, 409 if a job is already running, otherwise streams progress.
- `POST /api/batch-print/cancel` — cancels by jobId. 400 on missing id, 404 on unknown job.
- See README for full request/response shapes and caps.

## Notable implementation details

- **One job at a time.** Slot is reserved atomically under a lock in the route handler, and released both in the generator's `finally` and via `response.call_on_close` so an aborted-before-iteration request doesn't leak the slot.
- **Client-generated jobId** so the React component can request cancellation before the `started` SSE event arrives (closes an unmount race).
- **Per-widget rename detection** with cross-widget propagation. Scoped to the changed widget's before/after variable set to avoid false-positive carry-across from unrelated edits.
- **Stable row id** (uuid per row) used as the React key so focus/selection follow rows across deletes.
- **Power-save aware** — batch endpoint participates in the existing USB-power activity tracking, and `power_save.record_activity()` fires on every iteration so long batches don't trip the idle timer mid-run.
- **SSE anti-buffering headers** (`Cache-Control: no-cache`, `X-Accel-Buffering: no`) so events stream through nginx/Komodo in real time.

## Validation caps

| Field | Max |
|---|---|
| `copies` | 999 |
| `pauseTime` | 60 s |
| rows | 1000 |
| total labels (rows × copies) | 10000 |
| total pause budget | 8 h |

## Version

`1.6.0` (MINOR — new feature, backward compatible). The release workflow will auto-tag and build a Docker image on merge.

## Test plan

- [x] Server: 203 pytest tests (29 new in `test_batch.py` covering validation paths, SSE event sequence, cancellation, 409 concurrency, header presence, job-cleanup, NaN/Infinity/non-scalar rejection)
- [x] Client: 52 vitest tests (rename heuristic across widgets, store actions, API helpers)
- [x] Docker smoke + Docker build CI passing
- [x] Manual: tested in browser via `npm run dev` — add variables, fill rows, preview rows, print, cancel mid-batch, save/load with batch data