### PR TITLE
Fix: add missing `printer_service.py` to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN pip install --no-cache-dir --no-deps labelle \
 WORKDIR /app
 
 # Copy Python server
-COPY server/app.py server/label_builder.py server/config.py server/virtual_printer.py server/
+COPY server/*.py server/
 
 # Copy built client assets from build stage
 COPY --from=build /app/server/dist-client/ server/dist-client/


### PR DESCRIPTION
### Description of Changes
- Updated Dockerfile to include `printer_service.py` in the `COPY` command, ensuring it's available within the container.