### PR TITLE
ci: build PR-tagged Docker images on every PR push

### DIFF
--- a/.github/workflows/pr-image.yml
+++ b/.github/workflows/pr-image.yml
@@ -1,27 +1,51 @@
 name: Build PR image
 
 # Builds a Docker image for every PR push and publishes it to GHCR
-# under `:pr-<N>` and `:<sha>` tags so it can be pulled and tested on
-# hardware (e.g. hector) without rebuilding manually on the Pi. Does
+# under `:pr-<N>` and `:<short-sha>` tags so it can be pulled and tested
+# on hardware (e.g. hector) without rebuilding manually on the Pi. Does
 # NOT touch `:latest` or `:vX.Y.Z` — those remain owned by release.yml
-# and are only updated on merge to main with a version bump.
+# and only update on merge to main with a version bump.
+#
+# On PR close (merged or not), a cleanup job deletes the `:pr-<N>`
+# image so it doesn't linger in GHCR forever.
+#
+# Fork PRs are skipped — their GITHUB_TOKEN is read-only and can't
+# push to GHCR or delete packages.
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, closed]
     branches: [main]
+
+# Cancel any in-flight build when a new commit is pushed to the same
+# PR. Avoids racing parallel multi-arch builds to the same `:pr-<N>`
+# tag (last-finished-wins, not last-pushed-wins).
+concurrency:
+  group: pr-image-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  # Validate the image actually starts and the API responds before
+  # publishing it — same reusable workflow that release.yml gates on.
+  smoke-test:
+    if: >-
+      github.event.action != 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    uses: ./.github/workflows/_docker-smoke-test.yml
+
   build-and-push:
+    needs: smoke-test
+    if: >-
+      github.event.action != 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-      pull-requests: write
 
     steps:
       - name: Checkout PR head
@@ -41,16 +65,26 @@ jobs:
 
       - name: Compute short SHA
         id: sha
-        run: echo "short=$(echo ${{ github.event.pull_request.head.sha }} | cut -c1-7)" >> "$GITHUB_OUTPUT"
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: echo "short=${HEAD_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=pr-${{ github.event.pull_request.number }}
+            type=raw,value=${{ steps.sha.outputs.short }}
 
       - name: Build and push multi-platform
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.sha.outputs.short }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             GIT_SHA=${{ steps.sha.outputs.short }}
             GIT_BRANCH=pr-${{ github.event.pull_request.number }}
@@ -75,3 +109,35 @@ jobs:
           curl http://localhost:5001/api/health
           \`\`\`
           EOF
+
+  # Delete the `:pr-<N>` image versions when the PR closes (merged or
+  # not). Old SHA-only versions left behind by superseded builds aren't
+  # explicitly cleaned here — they become untagged and can be reaped by
+  # a GHCR retention policy if needed.
+  cleanup:
+    if: >-
+      github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Delete PR image versions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_TAG: pr-${{ github.event.pull_request.number }}
+          OWNER: ${{ github.repository_owner }}
+          PACKAGE: ${{ github.event.repository.name }}
+        run: |
+          set -eu
+          VERSIONS=$(gh api \
+            "/users/$OWNER/packages/container/$PACKAGE/versions" --paginate \
+            --jq ".[] | select(.metadata.container.tags | index(\"$PR_TAG\")) | .id" || true)
+          if [ -z "$VERSIONS" ]; then
+            echo "No versions tagged $PR_TAG to delete"
+            exit 0
+          fi
+          for VERSION_ID in $VERSIONS; do
+            echo "Deleting version $VERSION_ID (tag $PR_TAG)"
+            gh api -X DELETE "/users/$OWNER/packages/container/$PACKAGE/versions/$VERSION_ID"
+          done

--- a/.github/workflows/pr-image.yml
+++ b/.github/workflows/pr-image.yml
@@ -1,0 +1,77 @@
+name: Build PR image
+
+# Builds a Docker image for every PR push and publishes it to GHCR
+# under `:pr-<N>` and `:<sha>` tags so it can be pulled and tested on
+# hardware (e.g. hector) without rebuilding manually on the Pi. Does
+# NOT touch `:latest` or `:vX.Y.Z` — those remain owned by release.yml
+# and are only updated on merge to main with a version bump.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute short SHA
+        id: sha
+        run: echo "short=$(echo ${{ github.event.pull_request.head.sha }} | cut -c1-7)" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push multi-platform
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.sha.outputs.short }}
+          build-args: |
+            GIT_SHA=${{ steps.sha.outputs.short }}
+            GIT_BRANCH=pr-${{ github.event.pull_request.number }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+
+      - name: Annotate run summary
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## PR image published
+
+          - \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}\`
+          - \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.sha.outputs.short }}\`
+
+          Pull and test on hector:
+          \`\`\`bash
+          docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}
+          docker run -d --rm --name labelle-pr-test --privileged \\
+            -v /dev/bus/usb:/dev/bus/usb -p 5001:5000 \\
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}
+          curl http://localhost:5001/api/health
+          \`\`\`
+          EOF

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,9 @@ jobs:
 
       - name: Compute short SHA
         id: sha
-        run: echo "short=$(echo ${{ github.sha }} | cut -c1-7)" >> "$GITHUB_OUTPUT"
+        env:
+          SHA: ${{ github.sha }}
+        run: echo "short=${SHA:0:7}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push multi-platform
         uses: docker/build-push-action@v6


### PR DESCRIPTION
## Summary
- New workflow `.github/workflows/pr-image.yml` builds the multi-arch Docker image on every PR push and publishes to GHCR as `:pr-<N>` and `:<short-sha>`.
- Does **not** touch `:latest` or `:vX.Y.Z` — those stay owned by `release.yml` and only update on merge to main with a version bump.
- This lets us pull the image on hector and run side-by-side against the production container (which keeps tracking `:latest`), so existing users of the project don't get in-flight PR work surfaced as pulled updates.

## Why
Other people have installed labelle-web, so we can't pin their Komodo stacks. Instead of trying to gate `:latest`, we keep `:latest` exactly as-is and add a parallel PR-image lane. Existing users see no change.

For our own development:
1. PR opens → image is built and pushed automatically
2. On hector: `docker pull ghcr.io/szrudi/labelle-web:pr-<N>` → run on port 5001 alongside prod
3. Smoke test against real USB hardware
4. Stack subsequent slice PRs on each other, each gets its own `:pr-<N>` image
5. Once the whole slice work is done, merge them sequentially with a single version bump (e.g. 1.4 → 1.5.0) so `:latest` only moves once

## Test plan
- [x] Workflow uses `pull_request` trigger so it self-bootstraps — this PR is the first one to trigger it. Build success here = green-light.
- [ ] Pull `ghcr.io/szrudi/labelle-web:pr-14` on hector and confirm it runs:
  ```bash
  docker pull ghcr.io/szrudi/labelle-web:pr-14
  docker run -d --rm --name pr-test --privileged -v /dev/bus/usb:/dev/bus/usb -p 5001:5000 ghcr.io/szrudi/labelle-web:pr-14
  curl http://localhost:5001/api/health
  ```
- [ ] Confirm `/api/health` reports the PR's SHA + `pr-14` branch (build-args wiring)
- [ ] Verify `:latest` on GHCR is unchanged after this workflow runs

## Version
No version bump — CI/CD only, no app behavior change. `:latest` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)