### PR TITLE
ci: run Tests + Build PR image on stacked PRs (drop branches filter)

### DIFF
--- a/.github/workflows/pr-image.yml
+++ b/.github/workflows/pr-image.yml
@@ -15,7 +15,10 @@ name: Build PR image
 on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
-    branches: [main]
+    # No `branches:` filter — stacked PRs (e.g. slice 2 targeting
+    # slice 1's branch instead of main) need a buildable image too,
+    # otherwise they can't be tested on hardware until the parent
+    # PR merges.
 
 # Cancel any in-flight build when a new commit is pushed to the same
 # PR. Avoids racing parallel multi-arch builds to the same `:pr-<N>`

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,10 @@ name: Tests
 on:
   push:
     branches: [main]
+  # Run on every PR regardless of base — stacked PRs (e.g. slice 2
+  # of a feature targeting slice 1's branch instead of main) need CI
+  # too, otherwise they ship blind.
   pull_request:
-    branches: [main]
 
 jobs:
   test:


### PR DESCRIPTION
## Why
Stacked PRs (PR-B targeting feature/A-branch instead of main, where feature/A is itself an open PR) currently get zero CI because both \`test.yml\` and \`pr-image.yml\` use \`pull_request: branches: [main]\` to filter. That makes the bottom slice of a stack a hard prerequisite for testing the upper slices — defeats the point of stacking. We just hit this with PR #15 sitting on top of PR #13.

## Change
- Drop the \`branches:\` filter from the \`pull_request\` trigger in both workflows
- Keep \`push: branches: [main]\` in test.yml so we don't fan out on random branch pushes
- \`release.yml\` is unaffected — it gates on Tests completing on main via \`workflow_run\`, which still requires the push path

## Test plan
- [x] This PR itself targets main, so it'll trigger the existing pull_request workflows on its own changes (self-bootstrap, same as PR #14)
- [ ] After merge: bring main into \`feature/usb-power\` (PR #13) and into \`feature/usb-power-auto-idle\` (PR #15). PR #15 should then start getting Tests + Build PR image runs on every push.

## Version
No version bump — CI config only, no app behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)