### PR TITLE
USB power save: persist hub/port + v1.5.3 release notes (slice 4, stacked on #17)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,10 @@ PORT=5000
 #
 # USB_POWER_SAVE=true
 # USB_POWER_SAVE_IDLE_MINUTES=60
+
+# Optional: where to persist the discovered printer (hub, port) so a
+# container restart can recover the cached value while the printer is
+# still powered off. Default lives inside the output mount which is
+# already persistent in the standard Docker deployment.
+#
+# LABELLE_STATE_FILE=/app/output/.labelle/state.json

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,33 @@
+# Labelle Web Environment Variables
+
+# Server port (default: 5000)
+PORT=5000
+
+# Optional: Configure virtual/virtual printers for testing multi-printer setup
+# These printers save labels as PNG files to the specified directories instead of physically printing.
+# Useful for development, testing, and archiving label output.
+#
+# Format: JSON array of objects with 'name' and 'path' fields
+# - name: Display name for the printer (will appear as "{name} (Virtual)" in UI)
+# - path: Directory path where label PNGs will be saved (created automatically if doesn't exist)
+#
+# Example 1: Single virtual printer
+# VIRTUAL_PRINTERS=[{"name":"Test Printer","path":"./output/test"}]
+#
+# Example 2: Multiple virtual printers (typical for testing multi-printer UI)
+VIRTUAL_PRINTERS=[{"name":"Office Printer","path":"./output/office"},{"name":"Warehouse Printer","path":"./output/warehouse"}]
+#
+# Example 3: Three printers with descriptive names
+# VIRTUAL_PRINTERS=[{"name":"Main Floor","path":"./output/main"},{"name":"Shipping Dept","path":"./output/shipping"},{"name":"Archives","path":"./output/archive"}]
+#
+# Note: Make sure the paths are accessible and have write permissions.
+# When using Docker, mount the output directory as a volume in compose.yaml
+
+# Optional: auto power-off the Dymo's USB port via uhubctl after the
+# server has been idle, and auto power-on when the page is opened.
+# Requires the host hub to support per-port power switching (ppps).
+# Default: disabled. Manual /api/power/* endpoints are always available
+# regardless of this setting.
+#
+# USB_POWER_SAVE=true
+# USB_POWER_SAVE_IDLE_MINUTES=60

--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@
 # Server port (default: 5000)
 PORT=5000
 
-# Optional: Configure virtual/virtual printers for testing multi-printer setup
+# Optional: Configure virtual printers for testing multi-printer setup
 # These printers save labels as PNG files to the specified directories instead of physically printing.
 # Useful for development, testing, and archiving label output.
 #
@@ -15,7 +15,7 @@ PORT=5000
 # VIRTUAL_PRINTERS=[{"name":"Test Printer","path":"./output/test"}]
 #
 # Example 2: Multiple virtual printers (typical for testing multi-printer UI)
-VIRTUAL_PRINTERS=[{"name":"Office Printer","path":"./output/office"},{"name":"Warehouse Printer","path":"./output/warehouse"}]
+# VIRTUAL_PRINTERS=[{"name":"Office Printer","path":"./output/office"},{"name":"Warehouse Printer","path":"./output/warehouse"}]
 #
 # Example 3: Three printers with descriptive names
 # VIRTUAL_PRINTERS=[{"name":"Main Floor","path":"./output/main"},{"name":"Shipping Dept","path":"./output/shipping"},{"name":"Archives","path":"./output/archive"}]

--- a/.github/release-notes/v1.5.3.md
+++ b/.github/release-notes/v1.5.3.md
@@ -1,0 +1,37 @@
+## USB Power Save 🔌
+
+Most DYMO LabelManager printers have a transformer that stays warm 24/7 — for printers you use a few times a day, that's wasted electricity and unnecessary wear. **The 1.5.x line adds optional power management** that powers off the printer's USB port via `uhubctl` when the server has been idle, and brings it back online transparently when you next open the page. The printer's status LED actually goes out, the transformer goes cold.
+
+### What you get when you opt in
+
+- **Automatic idle power-off.** Set `USB_POWER_SAVE=true` in your `.env`. After `USB_POWER_SAVE_IDLE_MINUTES` (default 60), the port is powered down. Opening the page or hitting any printer endpoint wakes it back up in ~1.5 s — usually before you notice.
+- **Manual on/off button** in the Settings bar with a status indicator dot. Hides itself if you've selected a virtual printer (nothing to control) or if your hub doesn't support per-port power switching.
+- **`/api/power/{status,on,off}` HTTP endpoints** for scripting and external integrations (e.g. Home Assistant).
+- **Survives restarts.** The discovered hub/port is persisted to disk so a container restart while the printer is off doesn't lose track of where to find it.
+
+### How to enable
+
+In your `.env`:
+
+```env
+USB_POWER_SAVE=true
+USB_POWER_SAVE_IDLE_MINUTES=60   # tune to taste
+```
+
+Then restart your container / service. That's it.
+
+### Requirements
+
+- A USB hub that supports per-port power switching (ppps). The VIA Labs **2109:3431** hub used in many Raspberry Pi setups works; cheaper passive hubs typically don't. Check with `sudo uhubctl` — your hub should list `ppps` in its features.
+- Linux host (`uhubctl` is Linux-only). Docker users: the existing privileged container with `/dev/bus/usb` mounted is sufficient; no new volume mounts required.
+
+### Safe by default
+
+If you don't set `USB_POWER_SAVE`, **nothing changes**. The auto-idle daemon doesn't start, the UI toggle stays hidden (unless you have a discoverable USB printer for manual control), and `/api/printers` behaves exactly as before. Upgrades are non-disruptive.
+
+### Notes for advanced users
+
+- Some hubs auto-resume ports they were told to power off, if Linux USB autosuspend is configured aggressively on the hub. If you find your port refusing to stay off, try `echo on > /sys/bus/usb/devices/<hub>/power/control` or a udev rule that disables autosuspend on your specific hub.
+- The state file location is overridable with `LABELLE_STATE_FILE` — defaults to `/app/output/.labelle/state.json` (inside the Docker output mount).
+
+---

--- a/.github/release-notes/v1.5.3.md
+++ b/.github/release-notes/v1.5.3.md
@@ -29,6 +29,14 @@ Then restart your container / service. That's it.
 
 If you don't set `USB_POWER_SAVE`, **nothing changes**. The auto-idle daemon doesn't start, the UI toggle stays hidden (unless you have a discoverable USB printer for manual control), and `/api/printers` behaves exactly as before. Upgrades are non-disruptive.
 
+### What if I move the printer to a different USB port?
+
+It just works — no manual reset needed. Every call that needs the printer runs a fresh `uhubctl` scan before falling back to the saved location, so the new port is picked up automatically on the next request and the saved state is updated.
+
+This holds across server restarts too: even if you reboot while the printer is unplugged and then plug it back into a different port, the first request after that re-discovers it.
+
+(Narrow edge case: if you happen to plug the printer into a port that was previously powered *off* by `uhubctl` and never turned back on, the device won't enumerate at all and the saved state can't help. Recover by plugging into a different port, or `sudo uhubctl -l <hub> -p <port> -a on` to wake the destination port manually.)
+
 ### Notes for advanced users
 
 - Some hubs auto-resume ports they were told to power off, if Linux USB autosuspend is configured aggressively on the hub. If you find your port refusing to stay off, try `echo on > /sys/bus/usb/devices/<hub>/power/control` or a udev rule that disables autosuspend on your specific hub.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,8 +98,24 @@ jobs:
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
 
+      # If `.github/release-notes/<tag>.md` exists, use it as the
+      # release body (e.g. for a user-friendly feature announcement).
+      # Auto-generated notes (PR titles) are still appended underneath
+      # by softprops/action-gh-release. Older tags without a file get
+      # only the auto-generated notes — same as before.
+      - name: Find release notes file
+        id: notes
+        run: |
+          NOTES_FILE=".github/release-notes/${{ needs.tag.outputs.tag }}.md"
+          if [ -f "$NOTES_FILE" ]; then
+            echo "path=$NOTES_FILE" >> "$GITHUB_OUTPUT"
+          else
+            echo "path=" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.tag.outputs.tag }}
+          body_path: ${{ steps.notes.outputs.path }}
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,9 +113,17 @@ jobs:
             echo "path=" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Create GitHub Release
+      - name: Create GitHub Release (with custom notes)
+        if: steps.notes.outputs.path != ''
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.tag.outputs.tag }}
           body_path: ${{ steps.notes.outputs.path }}
+          generate_release_notes: true
+
+      - name: Create GitHub Release (auto-generated only)
+        if: steps.notes.outputs.path == ''
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.tag.outputs.tag }}
           generate_release_notes: true

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ __pycache__/
 # Environment
 .env
 .env.*
+!.env.example
 /.venv/
 labelle-main/
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ You can fight against AI usage or learn to embrace it as a new way of working. I
 - **Virtual printers** -- configure virtual printers that save labels as PNG images, JSON data, or both (great for testing, archiving, and development)
 - **Save/load labels** -- export label designs to JSON files and load them back, with embedded image data for portability
 - **Print via labelle** -- sends labels to the printer using the labelle Python library over USB
+- **USB power save** -- optionally power off the printer's USB port via uhubctl when the server is idle, and power it back on automatically when the page is opened (opt-in via `USB_POWER_SAVE=true`)
 
 ## Prerequisites
 
@@ -234,6 +235,18 @@ Upload an image for use in image widgets. Accepts `multipart/form-data` with a `
 **Response:** `{ "filename": "uuid.png" }`
 
 The returned filename is used in the `image` widget's `filename` field for subsequent print/preview requests.
+
+### `GET /api/power/status`, `POST /api/power/on`, `POST /api/power/off`
+
+Manual USB port power control for the Dymo printer via `uhubctl`. Available regardless of `USB_POWER_SAVE` — they're inert when not called. Requires a hub that supports per-port power switching (ppps) and `uhubctl` on PATH (already installed in the Docker image).
+
+**Response (all three):** `{ "hub": "1-1", "port": 3, "powered": true, "connected": true }` plus `status: "success"` on the POST variants. `404` if no printer can be located, `500` with a JSON `{status, message}` envelope if uhubctl fails or its output can't be parsed.
+
+## Power saving (auto idle)
+
+Set `USB_POWER_SAVE=true` to have the server power off the Dymo's USB port after `USB_POWER_SAVE_IDLE_MINUTES` (default 60) of no activity, and power it back on automatically when the page is opened. The transformer in DYMO USB labelers runs warm even when idle, so this saves a noticeable amount of electricity for printers that are only used occasionally.
+
+Activity is recorded by any API call except `/api/health` (so monitoring polls don't keep the printer awake) and `/api/power/*` (manual control doesn't feed back into the timer). The first `/api/printers`, `/api/preview`, `/api/print`, or `/api/upload-image` call after an auto power-off blocks ~1.5 s while the port is brought back up and the device re-enumerates on the USB bus.
 
 ## License
 

--- a/client/src/components/PowerToggle.test.tsx
+++ b/client/src/components/PowerToggle.test.tsx
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+vi.mock("../lib/api", () => ({
+  fetchPowerStatus: vi.fn(),
+  powerOn: vi.fn(),
+  powerOff: vi.fn(),
+}));
+
+import { PowerToggle } from "./PowerToggle";
+import * as api from "../lib/api";
+import type { PowerStatus } from "../types/label";
+
+const mockFetch = vi.mocked(api.fetchPowerStatus);
+const mockOn = vi.mocked(api.powerOn);
+const mockOff = vi.mocked(api.powerOff);
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  mockOn.mockReset();
+  mockOff.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("PowerToggle", () => {
+  it("renders nothing while the initial status is loading", () => {
+    mockFetch.mockReturnValue(new Promise(() => {})); // never resolves
+    const { container } = render(<PowerToggle />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when the server reports no controllable printer (null)", async () => {
+    mockFetch.mockResolvedValue(null);
+    const { container } = render(<PowerToggle />);
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  it("shows powered-on state with a Turn off button", async () => {
+    mockFetch.mockResolvedValue({
+      hub: "1-1",
+      port: 3,
+      powered: true,
+      connected: true,
+    });
+    render(<PowerToggle />);
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /turn off/i })).toBeInTheDocument();
+    });
+  });
+
+  it("shows powered-off state with a Turn on button", async () => {
+    mockFetch.mockResolvedValue({
+      hub: "1-1",
+      port: 3,
+      powered: false,
+      connected: false,
+    });
+    render(<PowerToggle />);
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /turn on/i })).toBeInTheDocument();
+    });
+  });
+
+  it("clicking Turn off calls powerOff and updates the UI", async () => {
+    mockFetch.mockResolvedValue({
+      hub: "1-1",
+      port: 3,
+      powered: true,
+      connected: true,
+    });
+    mockOff.mockResolvedValue({
+      hub: "1-1",
+      port: 3,
+      powered: false,
+      connected: false,
+    });
+    render(<PowerToggle />);
+    const btn = await screen.findByRole("button", { name: /turn off/i });
+    await userEvent.click(btn);
+    expect(mockOff).toHaveBeenCalledOnce();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /turn on/i })).toBeInTheDocument();
+    });
+  });
+
+  it("clicking Turn on calls powerOn and updates the UI", async () => {
+    mockFetch.mockResolvedValue({
+      hub: "1-1",
+      port: 3,
+      powered: false,
+      connected: false,
+    });
+    mockOn.mockResolvedValue({
+      hub: "1-1",
+      port: 3,
+      powered: true,
+      connected: true,
+    });
+    render(<PowerToggle />);
+    const btn = await screen.findByRole("button", { name: /turn on/i });
+    await userEvent.click(btn);
+    expect(mockOn).toHaveBeenCalledOnce();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /turn off/i })).toBeInTheDocument();
+    });
+  });
+
+  it("disables the button and shows a pending label while a toggle is in flight", async () => {
+    mockFetch.mockResolvedValue({
+      hub: "1-1",
+      port: 3,
+      powered: false,
+      connected: false,
+    });
+    // Block powerOn so we can observe the in-flight state
+    let resolveOn: (v: PowerStatus) => void = () => {};
+    mockOn.mockReturnValue(
+      new Promise<PowerStatus>((resolve) => {
+        resolveOn = resolve;
+      }),
+    );
+    render(<PowerToggle />);
+    const btn = await screen.findByRole("button", { name: /turn on/i });
+    await userEvent.click(btn);
+    // While the request is pending, the button is disabled and shows the
+    // pending label so the user sees something is happening (~1.5s).
+    expect(screen.getByRole("button", { name: /powering on/i })).toBeDisabled();
+    resolveOn({ hub: "1-1", port: 3, powered: true, connected: true });
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /turn off/i })).toBeInTheDocument();
+    });
+  });
+
+  it("recovers gracefully when a toggle fails (button re-enabled, state unchanged)", async () => {
+    mockFetch.mockResolvedValue({
+      hub: "1-1",
+      port: 3,
+      powered: true,
+      connected: true,
+    });
+    mockOff.mockRejectedValue(new Error("uhubctl exploded"));
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    render(<PowerToggle />);
+    const btn = await screen.findByRole("button", { name: /turn off/i });
+    await userEvent.click(btn);
+    // After the rejection the button is back to its "Turn off" state,
+    // not stuck in pending, and the user can retry.
+    await waitFor(() => {
+      const retry = screen.getByRole("button", { name: /turn off/i });
+      expect(retry).not.toBeDisabled();
+    });
+    consoleSpy.mockRestore();
+  });
+});

--- a/client/src/components/PowerToggle.tsx
+++ b/client/src/components/PowerToggle.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from "react";
+import { fetchPowerStatus, powerOn, powerOff } from "../lib/api";
+import type { PowerStatus } from "../types/label";
+
+// `undefined` = initial fetch in flight, `null` = server has no
+// controllable printer (404 from /api/power/status), object = live
+// state. The component renders nothing in the first two cases — a
+// deployment without per-port USB power switching shouldn't see the
+// toggle at all.
+type Status = PowerStatus | null | undefined;
+
+export function PowerToggle() {
+  const [status, setStatus] = useState<Status>(undefined);
+  // null = no toggle in flight; "on"/"off" = the action that's running
+  // (used both for the disabled-while-pending logic and for the
+  // accessible button label so screen readers see "Powering on...").
+  const [pending, setPending] = useState<"on" | "off" | null>(null);
+
+  useEffect(() => {
+    fetchPowerStatus()
+      .then(setStatus)
+      .catch((e: unknown) => {
+        // Treat fetch failure the same as 404 so a broken /api/power
+        // endpoint hides the UI rather than rendering it in a stuck
+        // state. The error is still logged for debugging.
+        console.error("Failed to fetch power status:", e);
+        setStatus(null);
+      });
+  }, []);
+
+  if (status === undefined || status === null) return null;
+
+  const handleToggle = async () => {
+    if (pending !== null) return;
+    const action = status.powered ? "off" : "on";
+    setPending(action);
+    try {
+      const next = action === "on" ? await powerOn() : await powerOff();
+      setStatus(next);
+    } catch (e: unknown) {
+      console.error(`Failed to power ${action}:`, e);
+      // Leave `status` untouched so the user can retry from the same
+      // state. `pending` is cleared in `finally`.
+    } finally {
+      setPending(null);
+    }
+  };
+
+  const label =
+    pending === "on"
+      ? "Powering on…"
+      : pending === "off"
+      ? "Powering off…"
+      : status.powered
+      ? "Turn off"
+      : "Turn on";
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <span className="text-gray-600 whitespace-nowrap">Printer power</span>
+      <span
+        className={`inline-block w-2 h-2 rounded-full ${
+          status.powered ? "bg-green-500" : "bg-gray-400"
+        }`}
+        aria-hidden="true"
+      />
+      <button
+        type="button"
+        className="text-xs px-2 py-1 bg-gray-200 hover:bg-gray-300 rounded disabled:opacity-50"
+        onClick={handleToggle}
+        disabled={pending !== null}
+      >
+        {label}
+      </button>
+    </div>
+  );
+}

--- a/client/src/components/SettingsBar.test.tsx
+++ b/client/src/components/SettingsBar.test.tsx
@@ -1,6 +1,22 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+
+// PowerToggle (rendered inside SettingsBar) fires fetchPowerStatus on
+// mount. Stub it out so these tests stay focused on the settings UI
+// and don't make real HTTP calls.
+vi.mock("../lib/api", () => ({
+  fetchPrinters: vi.fn().mockResolvedValue([]),
+  fetchPowerStatus: vi.fn().mockResolvedValue({
+    hub: "1-1",
+    port: 3,
+    powered: true,
+    connected: true,
+  }),
+  powerOn: vi.fn(),
+  powerOff: vi.fn(),
+}));
+
 import { SettingsBar } from "./SettingsBar";
 import { useLabelStore } from "../state/useLabelStore";
 import type { PrinterInfo } from "../types/label";
@@ -104,5 +120,50 @@ describe("SettingsBar printer selector", () => {
     await userEvent.selectOptions(select, "");
 
     expect(useLabelStore.getState().settings.printerId).toBeUndefined();
+  });
+});
+
+describe("SettingsBar power toggle visibility", () => {
+  it("shows the power toggle when a real USB printer is selected", async () => {
+    useLabelStore.setState({
+      availablePrinters: twoPrinters,
+      settings: { ...useLabelStore.getState().settings, printerId: "usb:1" },
+    });
+    render(<SettingsBar />);
+    screen.getByText("Settings").click();
+
+    await waitFor(() => {
+      expect(screen.getByText("Printer power")).toBeInTheDocument();
+    });
+  });
+
+  it("shows the power toggle on Auto-select (no printerId)", async () => {
+    useLabelStore.setState({
+      availablePrinters: twoPrinters,
+      settings: { ...useLabelStore.getState().settings, printerId: undefined },
+    });
+    render(<SettingsBar />);
+    screen.getByText("Settings").click();
+
+    await waitFor(() => {
+      expect(screen.getByText("Printer power")).toBeInTheDocument();
+    });
+  });
+
+  it("hides the power toggle when a virtual printer is selected", async () => {
+    useLabelStore.setState({
+      availablePrinters: twoPrinters,
+      settings: {
+        ...useLabelStore.getState().settings,
+        printerId: "virtual:Office",
+      },
+    });
+    render(<SettingsBar />);
+    screen.getByText("Settings").click();
+
+    // Even after the api mock resolves, "Printer power" should never
+    // appear because PowerToggle isn't rendered at all.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(screen.queryByText("Printer power")).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/SettingsBar.tsx
+++ b/client/src/components/SettingsBar.tsx
@@ -3,6 +3,7 @@ import { TAPE_SIZES, LABEL_COLORS } from "../lib/constants";
 import { fetchPrinters } from "../lib/api";
 import type { TapeSize, Alignment, LabelColor } from "../types/label";
 import { useState } from "react";
+import { PowerToggle } from "./PowerToggle";
 
 export function SettingsBar() {
   const settings = useLabelStore((s) => s.settings);
@@ -65,6 +66,8 @@ export function SettingsBar() {
           </button>
         </>
       )}
+
+      <PowerToggle />
 
       <Field label="Tape (mm)">
         <select

--- a/client/src/components/SettingsBar.tsx
+++ b/client/src/components/SettingsBar.tsx
@@ -33,6 +33,16 @@ export function SettingsBar() {
   // - Support printer-specific preset configurations
   const showPrinterSelector = availablePrinters.length > 1;
 
+  // Hide the USB power toggle when a virtual printer is selected —
+  // virtual printers don't have a USB port to power off. When
+  // Auto-select is active or a real USB printer is selected, the
+  // toggle stays visible (and itself hides if the server can't
+  // resolve a controllable port).
+  const selectedPrinter = settings.printerId
+    ? availablePrinters.find((p) => p.id === settings.printerId)
+    : null;
+  const selectedIsVirtual = selectedPrinter?.vendorProductId === "virtual";
+
   return (
     <details className="bg-white rounded-lg shadow">
       <summary className="cursor-pointer select-none p-3 text-sm font-medium text-gray-700">
@@ -67,7 +77,7 @@ export function SettingsBar() {
         </>
       )}
 
-      <PowerToggle />
+      {!selectedIsVirtual && <PowerToggle />}
 
       <Field label="Tape (mm)">
         <select

--- a/client/src/lib/api.test.ts
+++ b/client/src/lib/api.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { fetchPrinters, printLabel, fetchServerPreview, uploadImage } from "./api";
+import {
+  fetchPrinters,
+  fetchPowerStatus,
+  powerOn,
+  powerOff,
+  printLabel,
+  fetchServerPreview,
+  uploadImage,
+} from "./api";
 import type { LabelWidget, LabelSettings } from "../types/label";
 
 const mockFetch = vi.fn();
@@ -133,6 +141,89 @@ describe("fetchServerPreview", () => {
     expect(mockFetch).toHaveBeenCalledWith("/api/preview", expect.objectContaining({
       signal: controller.signal,
     }));
+  });
+});
+
+describe("fetchPowerStatus", () => {
+  it("returns the power status on 200", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ hub: "1-1", port: 3, powered: true, connected: true }),
+    });
+
+    const result = await fetchPowerStatus();
+    expect(result).toEqual({ hub: "1-1", port: 3, powered: true, connected: true });
+    expect(mockFetch).toHaveBeenCalledWith("/api/power/status");
+  });
+
+  it("returns null on 404 (no controllable printer)", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      json: async () => ({ status: "error", message: "Printer not detected" }),
+    });
+
+    const result = await fetchPowerStatus();
+    expect(result).toBeNull();
+  });
+
+  it("throws with server error message on 500", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({ status: "error", message: "uhubctl failed" }),
+    });
+
+    await expect(fetchPowerStatus()).rejects.toThrow("uhubctl failed");
+  });
+});
+
+describe("powerOn", () => {
+  it("sends POST and returns the updated status", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        status: "success",
+        hub: "1-1",
+        port: 3,
+        powered: true,
+        connected: true,
+      }),
+    });
+
+    const result = await powerOn();
+    expect(result).toEqual({ hub: "1-1", port: 3, powered: true, connected: true });
+    expect(mockFetch).toHaveBeenCalledWith("/api/power/on", { method: "POST" });
+  });
+
+  it("throws with server error message on failure", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({ status: "error", message: "uhubctl: hub not found" }),
+    });
+
+    await expect(powerOn()).rejects.toThrow("uhubctl: hub not found");
+  });
+});
+
+describe("powerOff", () => {
+  it("sends POST and returns the updated status", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        status: "success",
+        hub: "1-1",
+        port: 3,
+        powered: false,
+        connected: false,
+      }),
+    });
+
+    const result = await powerOff();
+    expect(result).toEqual({ hub: "1-1", port: 3, powered: false, connected: false });
+    expect(mockFetch).toHaveBeenCalledWith("/api/power/off", { method: "POST" });
   });
 });
 

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,4 +1,9 @@
-import type { LabelWidget, LabelSettings, PrinterInfo } from "../types/label";
+import type {
+  LabelWidget,
+  LabelSettings,
+  PrinterInfo,
+  PowerStatus,
+} from "../types/label";
 
 interface PrintResponse {
   status: string;
@@ -7,6 +12,10 @@ interface PrintResponse {
 
 interface PrintersResponse {
   printers: PrinterInfo[];
+}
+
+interface PowerResponse extends PowerStatus {
+  status?: string;
 }
 
 export async function printLabel(
@@ -63,4 +72,38 @@ export async function fetchPrinters(): Promise<PrinterInfo[]> {
   }
   const data = (await res.json()) as PrintersResponse;
   return data.printers;
+}
+
+// 404 here means the server can't resolve a controllable USB port for
+// the Dymo — either no printer detected or no cached port. UI treats
+// that as "this deployment doesn't have USB power control" and hides
+// the toggle. Non-200/404 errors propagate so the user sees them.
+async function _readPowerResponse(res: Response): Promise<PowerStatus> {
+  if (!res.ok) {
+    const err = (await res.json()) as PrintResponse;
+    throw new Error(err.message);
+  }
+  const data = (await res.json()) as PowerResponse;
+  return {
+    hub: data.hub,
+    port: data.port,
+    powered: data.powered,
+    connected: data.connected,
+  };
+}
+
+export async function fetchPowerStatus(): Promise<PowerStatus | null> {
+  const res = await fetch("/api/power/status");
+  if (res.status === 404) return null;
+  return _readPowerResponse(res);
+}
+
+export async function powerOn(): Promise<PowerStatus> {
+  const res = await fetch("/api/power/on", { method: "POST" });
+  return _readPowerResponse(res);
+}
+
+export async function powerOff(): Promise<PowerStatus> {
+  const res = await fetch("/api/power/off", { method: "POST" });
+  return _readPowerResponse(res);
 }

--- a/client/src/types/label.ts
+++ b/client/src/types/label.ts
@@ -68,6 +68,13 @@ export interface PrinterInfo {
   serialNumber?: string;
 }
 
+export interface PowerStatus {
+  hub: string;
+  port: number;
+  powered: boolean;
+  connected: boolean;
+}
+
 export interface LabelSettings {
   tapeSizeMm: TapeSize;
   marginPx: number;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labelle-web",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": true,
   "description": "Web interface for labelle DYMO label printers",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labelle-web",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "private": true,
   "description": "Web interface for labelle DYMO label printers",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labelle-web",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "private": true,
   "description": "Web interface for labelle DYMO label printers",
   "scripts": {

--- a/server/app.py
+++ b/server/app.py
@@ -14,6 +14,7 @@ from flask import Flask, jsonify, request, send_from_directory
 from flask_cors import CORS
 from werkzeug.utils import secure_filename
 
+import power_save
 import usb_power
 from label_builder import preview_label
 from printer_service import list_printers, print_label
@@ -22,11 +23,45 @@ from printer_service import list_printers, print_label
 # time to re-enumerate on the USB bus.
 POWER_ON_SETTLE_SECONDS = 1.5
 
+# Routes that should NOT count as "activity" for the idle timer:
+# - /api/health: monitoring tools poll it constantly, would keep the
+#   printer awake forever
+# - /api/power/*: manual control endpoints, shouldn't feed back into
+#   the auto-idle logic
+_POWER_SAVE_IGNORED_PATHS = ("/api/health",)
+_POWER_SAVE_IGNORED_PREFIXES = ("/api/power/",)
+
+# Routes that need the printer to be powered on. The before_request
+# hook will block on a power-on for these if the saver has turned the
+# port off.
+_PRINTER_USING_PATHS = ("/api/print", "/api/preview", "/api/printers", "/api/upload-image")
+
 app = Flask(__name__, static_folder=None)
 CORS(app)
 
 DIST_DIR = os.path.join(os.path.dirname(__file__), "dist-client")
 UPLOAD_DIR = tempfile.mkdtemp(prefix="labelle-uploads-")
+
+
+@app.before_request
+def _track_activity_and_wake_printer():
+    path = request.path
+    if path in _POWER_SAVE_IGNORED_PATHS:
+        return
+    if any(path.startswith(p) for p in _POWER_SAVE_IGNORED_PREFIXES):
+        return
+    power_save.record_activity()
+    if path in _PRINTER_USING_PATHS:
+        try:
+            power_save.ensure_powered()
+        except Exception:
+            # ensure_powered failures must not break the request — the
+            # downstream handler will fail loudly enough on its own if
+            # the printer really isn't there.
+            traceback.print_exc()
+
+
+power_save.start()
 
 
 @app.route("/api/print", methods=["POST"])

--- a/server/power_save.py
+++ b/server/power_save.py
@@ -26,9 +26,20 @@ logger = logging.getLogger(__name__)
 _CHECK_INTERVAL_SECONDS = 60
 
 # Tracks the last "meaningful" request time (not /api/health or
-# /api/power/*). Module-global, intentionally unlocked — see the
-# rationale in usb_power._last_known_port for the same pattern.
+# /api/power/*). Reads are unlocked (CPython makes a single
+# assignment atomic under the GIL); writes happen from request
+# handlers via `record_activity()`. Decisions that *act* on this
+# value (`check_idle()` powering off) re-check it under `_LOCK`.
 _last_activity: float = time.monotonic()
+
+# Serializes `check_idle()` (specifically its decision-to-power-off
+# critical region) with `ensure_powered()` so the idle daemon can't
+# call `power_off()` while a request handler is in the middle of
+# bringing the port up. Without this, the daemon's slow subprocess
+# calls (`find_or_recall_printer_port`, `get_port_status`) open a
+# window where a fresh request can complete `ensure_powered()` and
+# proceed to use the printer just before the daemon issues `off`.
+_LOCK = threading.Lock()
 
 # Power-on settle delay so the device has time to re-enumerate before
 # the next status read / handler runs against it.
@@ -54,17 +65,24 @@ def ensure_powered() -> bool:
     Returns True iff a power-on was performed. No-op when the saver
     is disabled, the printer isn't known, or it's already powered.
     Blocks ~1.5s on power-on so callers don't race re-enumeration.
+
+    Holds `_LOCK` for the status-check + potential power-on so the
+    idle daemon can't interleave a power-off into the critical
+    region.
     """
     if not is_enabled():
         return False
-    port = usb_power.find_or_recall_printer_port()
-    if not port:
-        return False
-    hub, port_num = port
-    status = usb_power.get_port_status(hub, port_num)
-    if status["powered"]:
-        return False
-    usb_power.power_on(hub, port_num)
+    with _LOCK:
+        port = usb_power.find_or_recall_printer_port()
+        if not port:
+            return False
+        hub, port_num = port
+        status = usb_power.get_port_status(hub, port_num)
+        if status["powered"]:
+            return False
+        usb_power.power_on(hub, port_num)
+    # Settle delay outside the lock — other requests don't need to
+    # wait on the device re-enumerating.
     time.sleep(_POWER_ON_SETTLE_SECONDS)
     return True
 
@@ -73,19 +91,26 @@ def check_idle() -> bool:
     """If the idle threshold is exceeded and the port is on, power it off.
 
     Returns True iff a power-off was performed. Safe to call repeatedly.
+
+    Re-checks `_last_activity` under `_LOCK` immediately before
+    `power_off()` so a request that bumps activity between the first
+    (unlocked) check and acquiring the lock will abort the power-off.
     """
     if not is_enabled():
         return False
     if time.monotonic() - _last_activity < idle_seconds():
         return False
-    port = usb_power.find_or_recall_printer_port()
-    if not port:
-        return False
-    hub, port_num = port
-    status = usb_power.get_port_status(hub, port_num)
-    if not status["powered"]:
-        return False
-    usb_power.power_off(hub, port_num)
+    with _LOCK:
+        if time.monotonic() - _last_activity < idle_seconds():
+            return False
+        port = usb_power.find_or_recall_printer_port()
+        if not port:
+            return False
+        hub, port_num = port
+        status = usb_power.get_port_status(hub, port_num)
+        if not status["powered"]:
+            return False
+        usb_power.power_off(hub, port_num)
     return True
 
 

--- a/server/power_save.py
+++ b/server/power_save.py
@@ -1,0 +1,114 @@
+"""Auto-idle USB power saver for the Dymo printer.
+
+Gated by `USB_POWER_SAVE=true`. When enabled, a background thread
+checks every minute whether the server has been idle longer than
+`USB_POWER_SAVE_IDLE_MINUTES` (default 60). If so, the printer's USB
+port is powered off via uhubctl. Manual `/api/power/*` endpoints in
+`app.py` stay always-on regardless of this gate — they're inert when
+not called, so there's no reason to hide them.
+
+Activity is recorded by `record_activity()` (wired from a Flask
+`before_request` hook). On a printer-using request, the hook also
+calls `ensure_powered()` so the printer is back on the bus by the
+time the handler runs.
+"""
+
+import logging
+import os
+import threading
+import time
+import traceback
+
+import usb_power
+
+logger = logging.getLogger(__name__)
+
+_CHECK_INTERVAL_SECONDS = 60
+
+# Tracks the last "meaningful" request time (not /api/health or
+# /api/power/*). Module-global, intentionally unlocked — see the
+# rationale in usb_power._last_known_port for the same pattern.
+_last_activity: float = time.monotonic()
+
+# Power-on settle delay so the device has time to re-enumerate before
+# the next status read / handler runs against it.
+_POWER_ON_SETTLE_SECONDS = 1.5
+
+
+def is_enabled() -> bool:
+    return os.environ.get("USB_POWER_SAVE", "").lower() in ("true", "1", "yes")
+
+
+def idle_seconds() -> int:
+    return int(os.environ.get("USB_POWER_SAVE_IDLE_MINUTES", "60")) * 60
+
+
+def record_activity() -> None:
+    global _last_activity
+    _last_activity = time.monotonic()
+
+
+def ensure_powered() -> bool:
+    """If we know the printer's port and it's off, power it on.
+
+    Returns True iff a power-on was performed. No-op when the saver
+    is disabled, the printer isn't known, or it's already powered.
+    Blocks ~1.5s on power-on so callers don't race re-enumeration.
+    """
+    if not is_enabled():
+        return False
+    port = usb_power.find_or_recall_printer_port()
+    if not port:
+        return False
+    hub, port_num = port
+    status = usb_power.get_port_status(hub, port_num)
+    if status["powered"]:
+        return False
+    usb_power.power_on(hub, port_num)
+    time.sleep(_POWER_ON_SETTLE_SECONDS)
+    return True
+
+
+def check_idle() -> bool:
+    """If the idle threshold is exceeded and the port is on, power it off.
+
+    Returns True iff a power-off was performed. Safe to call repeatedly.
+    """
+    if not is_enabled():
+        return False
+    if time.monotonic() - _last_activity < idle_seconds():
+        return False
+    port = usb_power.find_or_recall_printer_port()
+    if not port:
+        return False
+    hub, port_num = port
+    status = usb_power.get_port_status(hub, port_num)
+    if not status["powered"]:
+        return False
+    usb_power.power_off(hub, port_num)
+    return True
+
+
+def _idle_loop() -> None:
+    """Background loop — runs forever in a daemon thread."""
+    while True:
+        time.sleep(_CHECK_INTERVAL_SECONDS)
+        try:
+            if check_idle():
+                logger.info("USB power-save: idle exceeded, port powered off")
+        except Exception:
+            # Swallow + log so the thread survives transient uhubctl
+            # failures (USB hub momentarily missing, etc.)
+            traceback.print_exc()
+
+
+def start() -> None:
+    """Spin up the background idle-check thread if the saver is enabled."""
+    if not is_enabled():
+        return
+    thread = threading.Thread(target=_idle_loop, daemon=True, name="usb-power-save")
+    thread.start()
+    logger.info(
+        "USB power-save enabled: will power off Dymo port after %d minutes idle",
+        idle_seconds() // 60,
+    )

--- a/server/tests/test_app.py
+++ b/server/tests/test_app.py
@@ -407,6 +407,69 @@ class TestApiPower:
         assert resp.get_json()["status"] == "error"
 
 
+class TestPowerSaveHook:
+    """The before_request hook should record activity for normal routes and
+    skip the noisy/feedback-loop ones (health, power-control)."""
+
+    @patch("app.power_save.record_activity")
+    def test_health_does_not_record_activity(self, mock_record, client):
+        client.get("/api/health")
+        mock_record.assert_not_called()
+
+    @patch("app.power_save.ensure_powered")
+    @patch("app.power_save.record_activity")
+    def test_power_status_does_not_record_activity(
+        self, mock_record, mock_ensure, client
+    ):
+        with patch("app.usb_power.find_or_recall_printer_port", return_value=None):
+            client.get("/api/power/status")
+        mock_record.assert_not_called()
+        mock_ensure.assert_not_called()
+
+    @patch("app.power_save.ensure_powered")
+    @patch("app.power_save.record_activity")
+    @patch("app.list_printers", return_value=[])
+    def test_printers_records_activity_and_wakes(
+        self, mock_list, mock_record, mock_ensure, client
+    ):
+        client.get("/api/printers")
+        mock_record.assert_called_once()
+        mock_ensure.assert_called_once()
+
+    @patch("app.power_save.ensure_powered")
+    @patch("app.power_save.record_activity")
+    @patch("app.preview_label")
+    def test_preview_records_activity_and_wakes(
+        self, mock_preview, mock_record, mock_ensure, client
+    ):
+        import io
+
+        img = Image.new("RGB", (10, 10), "white")
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        mock_preview.return_value = buf.getvalue()
+        client.post(
+            "/api/preview",
+            data=json.dumps(
+                {"widgets": [{"type": "text", "text": "x", "id": "1"}], "settings": {}}
+            ),
+            content_type="application/json",
+        )
+        mock_record.assert_called_once()
+        mock_ensure.assert_called_once()
+
+    @patch("app.power_save.ensure_powered")
+    @patch("app.power_save.record_activity")
+    @patch("app.list_printers", return_value=[])
+    def test_ensure_powered_failure_does_not_break_request(
+        self, mock_list, mock_record, mock_ensure, client
+    ):
+        mock_ensure.side_effect = RuntimeError("uhubctl exploded")
+        resp = client.get("/api/printers")
+        # The before_request hook swallowed the failure; the route still 200s.
+        assert resp.status_code == 200
+
+
 class TestApiPrintErrors:
     @patch("app.print_label")
     def test_returns_400_for_empty_widgets(self, mock_print, client):

--- a/server/tests/test_power_save.py
+++ b/server/tests/test_power_save.py
@@ -161,6 +161,35 @@ class TestCheckIdle:
         assert power_save.check_idle() is False
         mock_off.assert_not_called()
 
+    @patch("power_save.usb_power.power_off")
+    @patch("power_save.usb_power.find_or_recall_printer_port")
+    def test_re_check_under_lock_aborts_when_activity_fresh(
+        self, mock_find, mock_off, monkeypatch
+    ):
+        """If a request bumps `_last_activity` between the unlocked first
+        check and the lock acquisition, the re-check inside the critical
+        region must abort the power-off.
+
+        Simulated by patching `time.monotonic` to return two values: a
+        far-future one for the first (unlocked) check so idle is
+        exceeded, then a close-to-`_last_activity` one for the re-check
+        so it looks fresh again.
+        """
+        monkeypatch.setenv("USB_POWER_SAVE", "true")
+        monkeypatch.setenv("USB_POWER_SAVE_IDLE_MINUTES", "1")  # 60s threshold
+
+        base = 1000.0
+        power_save._last_activity = base
+        with patch(
+            "power_save.time.monotonic",
+            side_effect=[base + 1000, base + 30],
+        ):
+            assert power_save.check_idle() is False
+
+        mock_off.assert_not_called()
+        # The re-check aborts before we ever shell out to uhubctl.
+        mock_find.assert_not_called()
+
 
 class TestStart:
     def test_does_not_start_thread_when_disabled(self, monkeypatch):

--- a/server/tests/test_power_save.py
+++ b/server/tests/test_power_save.py
@@ -1,0 +1,178 @@
+import time
+from unittest.mock import patch
+
+import pytest
+
+import power_save
+import usb_power
+
+
+@pytest.fixture(autouse=True)
+def reset_state(monkeypatch):
+    """Fresh module state per test so cross-test pollution can't hide bugs."""
+    monkeypatch.setattr(power_save, "_last_activity", time.monotonic())
+    yield
+
+
+class TestIsEnabled:
+    def test_default_disabled(self, monkeypatch):
+        monkeypatch.delenv("USB_POWER_SAVE", raising=False)
+        assert power_save.is_enabled() is False
+
+    @pytest.mark.parametrize("val", ["true", "True", "TRUE", "1", "yes"])
+    def test_truthy_values_enable(self, monkeypatch, val):
+        monkeypatch.setenv("USB_POWER_SAVE", val)
+        assert power_save.is_enabled() is True
+
+    @pytest.mark.parametrize("val", ["false", "0", "no", "off", ""])
+    def test_falsy_values_disable(self, monkeypatch, val):
+        monkeypatch.setenv("USB_POWER_SAVE", val)
+        assert power_save.is_enabled() is False
+
+
+class TestIdleSeconds:
+    def test_default_60_minutes(self, monkeypatch):
+        monkeypatch.delenv("USB_POWER_SAVE_IDLE_MINUTES", raising=False)
+        assert power_save.idle_seconds() == 3600
+
+    def test_custom_value(self, monkeypatch):
+        monkeypatch.setenv("USB_POWER_SAVE_IDLE_MINUTES", "30")
+        assert power_save.idle_seconds() == 1800
+
+
+class TestRecordActivity:
+    def test_updates_last_activity(self):
+        before = power_save._last_activity
+        time.sleep(0.001)  # ensure monotonic ticks
+        power_save.record_activity()
+        assert power_save._last_activity > before
+
+
+class TestEnsurePowered:
+    @patch("power_save.usb_power.power_on")
+    @patch("power_save.usb_power.get_port_status")
+    @patch("power_save.usb_power.find_or_recall_printer_port")
+    def test_no_op_when_disabled(
+        self, mock_find, mock_status, mock_on, monkeypatch
+    ):
+        monkeypatch.delenv("USB_POWER_SAVE", raising=False)
+        assert power_save.ensure_powered() is False
+        mock_find.assert_not_called()
+        mock_on.assert_not_called()
+
+    @patch("power_save.usb_power.power_on")
+    @patch("power_save.usb_power.get_port_status")
+    @patch("power_save.usb_power.find_or_recall_printer_port")
+    def test_no_op_when_no_printer_known(
+        self, mock_find, mock_status, mock_on, monkeypatch
+    ):
+        monkeypatch.setenv("USB_POWER_SAVE", "true")
+        mock_find.return_value = None
+        assert power_save.ensure_powered() is False
+        mock_on.assert_not_called()
+
+    @patch("power_save.usb_power.power_on")
+    @patch("power_save.usb_power.get_port_status")
+    @patch("power_save.usb_power.find_or_recall_printer_port")
+    def test_no_op_when_already_powered(
+        self, mock_find, mock_status, mock_on, monkeypatch
+    ):
+        monkeypatch.setenv("USB_POWER_SAVE", "true")
+        mock_find.return_value = ("1-1", 3)
+        mock_status.return_value = {"powered": True, "connected": True}
+        assert power_save.ensure_powered() is False
+        mock_on.assert_not_called()
+
+    @patch("power_save.time.sleep")
+    @patch("power_save.usb_power.power_on")
+    @patch("power_save.usb_power.get_port_status")
+    @patch("power_save.usb_power.find_or_recall_printer_port")
+    def test_powers_on_when_off(
+        self, mock_find, mock_status, mock_on, mock_sleep, monkeypatch
+    ):
+        monkeypatch.setenv("USB_POWER_SAVE", "true")
+        mock_find.return_value = ("1-1", 3)
+        mock_status.return_value = {"powered": False, "connected": False}
+        assert power_save.ensure_powered() is True
+        mock_on.assert_called_once_with("1-1", 3)
+
+
+class TestCheckIdle:
+    @patch("power_save.usb_power.power_off")
+    @patch("power_save.usb_power.get_port_status")
+    @patch("power_save.usb_power.find_or_recall_printer_port")
+    def test_no_op_when_disabled(
+        self, mock_find, mock_status, mock_off, monkeypatch
+    ):
+        monkeypatch.delenv("USB_POWER_SAVE", raising=False)
+        assert power_save.check_idle() is False
+        mock_off.assert_not_called()
+
+    @patch("power_save.usb_power.power_off")
+    @patch("power_save.usb_power.get_port_status")
+    @patch("power_save.usb_power.find_or_recall_printer_port")
+    def test_no_op_when_recently_active(
+        self, mock_find, mock_status, mock_off, monkeypatch
+    ):
+        monkeypatch.setenv("USB_POWER_SAVE", "true")
+        monkeypatch.setenv("USB_POWER_SAVE_IDLE_MINUTES", "60")
+        power_save._last_activity = time.monotonic()  # just now
+        assert power_save.check_idle() is False
+        mock_off.assert_not_called()
+
+    @patch("power_save.usb_power.power_off")
+    @patch("power_save.usb_power.get_port_status")
+    @patch("power_save.usb_power.find_or_recall_printer_port")
+    def test_no_op_when_already_off(
+        self, mock_find, mock_status, mock_off, monkeypatch
+    ):
+        monkeypatch.setenv("USB_POWER_SAVE", "true")
+        monkeypatch.setenv("USB_POWER_SAVE_IDLE_MINUTES", "1")
+        # Force the idle threshold to be exceeded
+        power_save._last_activity = time.monotonic() - 1000
+        mock_find.return_value = ("1-1", 3)
+        mock_status.return_value = {"powered": False, "connected": False}
+        assert power_save.check_idle() is False
+        mock_off.assert_not_called()
+
+    @patch("power_save.usb_power.power_off")
+    @patch("power_save.usb_power.get_port_status")
+    @patch("power_save.usb_power.find_or_recall_printer_port")
+    def test_powers_off_when_idle_exceeded(
+        self, mock_find, mock_status, mock_off, monkeypatch
+    ):
+        monkeypatch.setenv("USB_POWER_SAVE", "true")
+        monkeypatch.setenv("USB_POWER_SAVE_IDLE_MINUTES", "1")
+        power_save._last_activity = time.monotonic() - 1000
+        mock_find.return_value = ("1-1", 3)
+        mock_status.return_value = {"powered": True, "connected": True}
+        assert power_save.check_idle() is True
+        mock_off.assert_called_once_with("1-1", 3)
+
+    @patch("power_save.usb_power.power_off")
+    @patch("power_save.usb_power.find_or_recall_printer_port")
+    def test_no_op_when_no_printer_known(
+        self, mock_find, mock_off, monkeypatch
+    ):
+        monkeypatch.setenv("USB_POWER_SAVE", "true")
+        monkeypatch.setenv("USB_POWER_SAVE_IDLE_MINUTES", "1")
+        power_save._last_activity = time.monotonic() - 1000
+        mock_find.return_value = None
+        assert power_save.check_idle() is False
+        mock_off.assert_not_called()
+
+
+class TestStart:
+    def test_does_not_start_thread_when_disabled(self, monkeypatch):
+        monkeypatch.delenv("USB_POWER_SAVE", raising=False)
+        with patch("power_save.threading.Thread") as mock_thread:
+            power_save.start()
+            mock_thread.assert_not_called()
+
+    def test_starts_daemon_thread_when_enabled(self, monkeypatch):
+        monkeypatch.setenv("USB_POWER_SAVE", "true")
+        with patch("power_save.threading.Thread") as mock_thread:
+            power_save.start()
+            mock_thread.assert_called_once()
+            assert mock_thread.call_args.kwargs["daemon"] is True
+            mock_thread.return_value.start.assert_called_once()

--- a/server/tests/test_smoke.py
+++ b/server/tests/test_smoke.py
@@ -14,6 +14,7 @@ SERVER_MODULES = [
     "app",
     "config",
     "label_builder",
+    "power_save",
     "printer_service",
     "usb_power",
     "virtual_printer",

--- a/server/tests/test_usb_power.py
+++ b/server/tests/test_usb_power.py
@@ -193,9 +193,9 @@ class TestStatePersistence:
         mock_run.return_value = _result(UHUBCTL_DEFAULT_OUTPUT)
         usb_power.find_or_recall_printer_port()
 
-        # Override the default arg of _save_state by calling _load_state
-        # against the same path the function just wrote to.
-        assert usb_power._load_state(state_file) == ("1-1", 3)
+        # Read it back through `_load_state()` with no arg so it
+        # resolves the same monkeypatched `_STATE_FILE`.
+        assert usb_power._load_state() == ("1-1", 3)
 
     def test_find_or_recall_does_not_rewrite_unchanged_value(
         self, mock_run, tmp_path, monkeypatch

--- a/server/tests/test_usb_power.py
+++ b/server/tests/test_usb_power.py
@@ -142,6 +142,75 @@ class TestPowerOnOff:
         ]
 
 
+class TestStatePersistence:
+    """The (hub, port) cache must survive a container restart so /api/power/on
+    can find the port even if the printer is currently powered off."""
+
+    def test_load_state_returns_none_when_file_missing(self, tmp_path):
+        assert usb_power._load_state(tmp_path / "absent.json") is None
+
+    def test_load_state_returns_tuple_when_file_valid(self, tmp_path):
+        p = tmp_path / "state.json"
+        p.write_text('{"hub": "1-1", "port": 3}')
+        assert usb_power._load_state(p) == ("1-1", 3)
+
+    def test_load_state_returns_none_when_json_corrupt(self, tmp_path):
+        p = tmp_path / "state.json"
+        p.write_text("{not json")
+        assert usb_power._load_state(p) is None
+
+    def test_load_state_returns_none_when_shape_wrong(self, tmp_path):
+        p = tmp_path / "state.json"
+        # port as string, not int
+        p.write_text('{"hub": "1-1", "port": "3"}')
+        assert usb_power._load_state(p) is None
+
+    def test_save_state_writes_round_trippable_json(self, tmp_path):
+        p = tmp_path / "state.json"
+        usb_power._save_state("2-4", 7, p)
+        assert usb_power._load_state(p) == ("2-4", 7)
+
+    def test_save_state_creates_parent_dirs(self, tmp_path):
+        p = tmp_path / "nested" / "dir" / "state.json"
+        usb_power._save_state("1-1", 3, p)
+        assert p.exists()
+
+    def test_save_state_swallows_write_errors(self, tmp_path):
+        # Make a path that can't be written (parent is a file, not a dir)
+        blocker = tmp_path / "blocker"
+        blocker.write_text("not a dir")
+        bad_path = blocker / "state.json"
+        # Should not raise — best-effort
+        usb_power._save_state("1-1", 3, bad_path)
+
+    def test_find_or_recall_persists_new_discovery_to_disk(
+        self, mock_run, tmp_path, monkeypatch
+    ):
+        state_file = tmp_path / "state.json"
+        monkeypatch.setattr(usb_power, "_STATE_FILE", state_file)
+        usb_power._last_known_port = None
+
+        mock_run.return_value = _result(UHUBCTL_DEFAULT_OUTPUT)
+        usb_power.find_or_recall_printer_port()
+
+        # Override the default arg of _save_state by calling _load_state
+        # against the same path the function just wrote to.
+        assert usb_power._load_state(state_file) == ("1-1", 3)
+
+    def test_find_or_recall_does_not_rewrite_unchanged_value(
+        self, mock_run, tmp_path, monkeypatch
+    ):
+        state_file = tmp_path / "state.json"
+        monkeypatch.setattr(usb_power, "_STATE_FILE", state_file)
+        usb_power._last_known_port = ("1-1", 3)
+
+        mock_run.return_value = _result(UHUBCTL_DEFAULT_OUTPUT)
+        usb_power.find_or_recall_printer_port()
+
+        # File should not exist — no write happened because value is unchanged
+        assert not state_file.exists()
+
+
 class TestLibusbCacheInvalidation:
     """power_on must invalidate the pyusb libusb cache so the next scan
     re-enumerates the device that just came back. power_off must NOT

--- a/server/usb_power.py
+++ b/server/usb_power.py
@@ -8,11 +8,16 @@ support per-port power switching (ppps) — confirmed for the 2109:3431 USB
 2.0 hub on hector.
 """
 
+import json
+import logging
 import os
 import re
 import subprocess
+from pathlib import Path
 
 import usb.backend.libusb1
+
+logger = logging.getLogger(__name__)
 
 UHUBCTL_BIN = os.environ.get("UHUBCTL_BIN", "uhubctl")
 DYMO_USB_ID = "0922:1002"
@@ -120,12 +125,62 @@ def power_off(hub: str, port: int) -> None:
     # power/status`) rather than libusb-based device enumeration.
 
 
+# Path where `_last_known_port` is persisted across container restarts.
+# Default lives inside the Docker output mount, which is already a
+# persistent volume in the standard deployment — avoids requiring a
+# new volume mount just for this state. Tests pass an explicit path.
+_STATE_FILE = Path(
+    os.environ.get("LABELLE_STATE_FILE", "/app/output/.labelle/state.json")
+)
+
+
+def _load_state(path: Path | None = None) -> tuple[str, int] | None:
+    """Read a previously-saved (hub, port) from disk, or None if absent/invalid."""
+    if path is None:
+        path = _STATE_FILE
+    try:
+        data = json.loads(path.read_text())
+    except FileNotFoundError:
+        return None
+    except (OSError, json.JSONDecodeError) as e:
+        logger.warning("Could not load printer port state from %s: %s", path, e)
+        return None
+    hub = data.get("hub")
+    port = data.get("port")
+    if isinstance(hub, str) and isinstance(port, int):
+        return hub, port
+    logger.warning(
+        "Ignoring printer port state from %s: unexpected shape %r", path, data
+    )
+    return None
+
+
+def _save_state(hub: str, port: int, path: Path | None = None) -> None:
+    """Persist (hub, port) so a container restart can recover the cache.
+
+    Best-effort: a write failure (read-only fs, missing volume mount,
+    permissions) only loses cross-restart memory, never breaks runtime.
+    """
+    if path is None:
+        path = _STATE_FILE
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"hub": hub, "port": port}))
+    except OSError as e:
+        logger.warning("Could not save printer port state to %s: %s", path, e)
+
+
 # Module-global, intentionally unlocked. waitress serves requests on
 # multiple threads, but Python's GIL makes the single-assignment update
 # atomic and the worst-case race outcome is "valid value overwritten by
 # another valid value" — benign for a single-printer setup. Revisit if
 # we ever need per-printer caching for multiple devices.
-_last_known_port: tuple[str, int] | None = None
+#
+# Seeded from disk at module load so a container restart while the
+# printer is powered off doesn't lose the port — without that, the
+# /api/power/on endpoint would 404 until the device was re-attached
+# (or manually re-powered via shell uhubctl).
+_last_known_port: tuple[str, int] | None = _load_state()
 
 
 def find_or_recall_printer_port(
@@ -137,10 +192,14 @@ def find_or_recall_printer_port(
     the USB tree — `find_printer_port` would return None and we'd have no
     way to power it back on. This falls back to the cached result.
 
+    On a live discovery (cache miss or hit-with-new-value) we persist the
+    new value to disk, so a container restart picks up where we left off.
+
     Thread safety: best-effort, see `_last_known_port` comment above.
     """
     global _last_known_port
     found = find_printer_port(vendor_product_id)
-    if found:
+    if found and found != _last_known_port:
         _last_known_port = found
+        _save_state(*found)
     return found or _last_known_port

--- a/server/usb_power.py
+++ b/server/usb_power.py
@@ -160,12 +160,20 @@ def _save_state(hub: str, port: int, path: Path | None = None) -> None:
 
     Best-effort: a write failure (read-only fs, missing volume mount,
     permissions) only loses cross-restart memory, never breaks runtime.
+
+    Writes are atomic-on-POSIX: serialize to a sibling `.tmp` file
+    first, then `os.replace()` over the target. A process interrupted
+    mid-write (or another thread writing concurrently) leaves the
+    target either fully old or fully new, never a torn JSON that
+    `_load_state` would have to discard.
     """
     if path is None:
         path = _STATE_FILE
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps({"hub": hub, "port": port}))
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(json.dumps({"hub": hub, "port": port}))
+        tmp.replace(path)
     except OSError as e:
         logger.warning("Could not save printer port state to %s: %s", path, e)
 


### PR DESCRIPTION
**Stacked on top of PR #17** (slice 3 — UI). Merge order: #13 → #15 → #17 → this. Final slice in the 1.5.x power-save line.

## Summary

Three changes that round out the USB power-save feature for its v1.5.3 release:

### 1. Cache persistence (`server/usb_power.py`)
`_last_known_port` is now seeded from disk at module load and saved on any new discovery. Default path is `/app/output/.labelle/state.json` inside the Docker output mount (already persistent), overridable via `LABELLE_STATE_FILE`.

Closes a real edge case I hit during dogfooding: container restart while the printer is powered off → `find_printer_port` returns None (device not on bus), in-memory cache is gone (process restart), so `/api/power/on` 404s and the user is stuck until they shell into the host to manually `uhubctl on`.

### 2. Per-tag custom release notes (`.github/workflows/release.yml`)
If `.github/release-notes/<tag>.md` exists, its content is used as the GitHub release body. Auto-generated notes (PR titles) get appended underneath. Older tags without a file fall back to the existing auto-only behavior.

### 3. v1.5.3 release content (`.github/release-notes/v1.5.3.md`)
Friendly user-facing description of the whole USB power-save feature as it lands at v1.5.3: what it does, how to enable, hub requirements, safe-by-default reassurance.

## Versioning

`1.5.2 → 1.5.3` (PATCH within the 1.5.x line). The 1.5.x line is the power-save feature; slices 1-4 each bump PATCH so each merge publishes a fresh GHCR image, but the user-facing story is "1.5 = USB power save shipped".

## Test plan
- [x] `pytest server/tests/` — 177 passed (9 new persistence tests)
- [x] Manual scenario test (simulated): write state file, kill process, restart, read state — `_last_known_port` seeded from disk ✓
- [ ] After merge: verify v1.5.3 release on GitHub has the custom description on top, auto-notes below.

## Stack notes
- Base: `feature/usb-power-ui` (PR #17). GitHub auto-retargets to main once #17 lands.
- Re-merge cascade may be needed if any parent PR force-pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)