### PR TITLE
Cut mark: dotted tear line between batch labels

### DIFF
--- a/.github/release-notes/v1.6.0.md
+++ b/.github/release-notes/v1.6.0.md
@@ -1,0 +1,44 @@
+## Batch print 🏷️
+
+Print many labels from one template. Drop `:varname:` placeholders into your widgets, fill in a row per label, hit print — the server streams progress label-by-label.
+
+### What you get
+
+- **Variables anywhere.** Put `:name:`, `:001:`, `:_foo:` etc. into text widgets, QR content, or barcode content. They're auto-detected.
+- **Spreadsheet UI.** Columns are the detected variables, rows are labels. Click the eye icon on a row to live-preview that row's values in the main preview pane.
+- **Add quickly.** `+ Add Variable` inserts a new placeholder (creating a text widget if you don't have one yet). `+ Add Row` adds another label.
+- **Smart renames.** Editing `:name:` → `:fullname:` in any widget renames it in every other widget that references it, and the row column header (and stored values) follow.
+- **Per-job knobs.** Copies per row (×N) and Pause (seconds between prints, for tear-off/sort time).
+- **Live progress + cancel.** Print button shows `Printing 7/30…` while it runs, with a Cancel button. Server-Sent Events stream `started`/`printing`/`printed`/`done`/`cancelled`/`error`.
+- **Round-trips through save/load.** Batch data is included in the `.json` label file so you can keep recipe + values together.
+
+### How to use it
+
+1. Open the **Batch Print** panel.
+2. Click **+ Add Variable**, or type `:name:` (or any `:word:`) into a text widget. The variable becomes a column in the panel.
+3. Fill in the rows — one row per label.
+4. (Optional) Set **Copies** (each row prints N times) and **Pause (s)** between prints.
+5. Click **Batch Print** — the button label shows the total label count.
+
+Batch mode auto-engages whenever your widgets contain at least one `:varname:` placeholder. No on/off toggle to forget.
+
+### API
+
+- `POST /api/batch-print` — SSE endpoint. Body: `widgets`, `settings`, `rows`, `copies`, `pauseTime`, optional `jobId`. Validation caps: copies ≤ 999, pauseTime ≤ 60s, rows ≤ 1000, total labels ≤ 10000, total pause budget ≤ 8h. Returns 409 if another job is already running.
+- `POST /api/batch-print/cancel` — body `{ "jobId": "…" }`. Returns 200 / 400 (missing id) / 404 (unknown id).
+
+SSE responses include `Cache-Control: no-cache` and `X-Accel-Buffering: no` so events flow through nginx/Komodo in real time.
+
+### Implementation notes
+
+- One batch job runs at a time. Slot is reserved atomically and released via both the generator's `finally` and `response.call_on_close`, so an aborted-before-iteration request doesn't leak the slot.
+- Client generates the `jobId` and stores it in a ref before the fetch — cancellation works even if the user navigates away before the `started` SSE event arrives.
+- Rename detection is scoped to the changed widget and copies values across so unrelated edits in two widgets don't false-positive into a migration.
+- Power-save aware: the batch endpoint participates in the existing USB idle tracker, and a heartbeat fires on every iteration so long batches don't trip the idle timer mid-run.
+- Each batch row has a stable internal id so React keeps focus/selection on the right row across deletes.
+
+### Safe by default
+
+If you don't add `:varname:` placeholders, nothing about your workflow changes — the Print button reads "Print Label" and behaves exactly as before.
+
+---

--- a/.github/release-notes/v1.6.1.md
+++ b/.github/release-notes/v1.6.1.md
@@ -1,0 +1,26 @@
+## Cut marks ✂️
+
+A small follow-up to the batch print feature: opt-in **tear/cut marks** between labels on a continuous tape run.
+
+Enable the **Cut mark** checkbox in the Batch Print panel and each printed label gets a 1-pixel-wide dotted column on its right edge (pixel on, two off, repeated for the tape's height). The result on tape:
+
+```
+[ label A ]┊[ label B ]┊[ label C ]┊
+```
+
+Pull the tape out of the printer, follow the dotted columns with scissors, done.
+
+### How to use it
+
+1. Open the Batch Print panel.
+2. Check **Cut mark** (next to Copies / Pause).
+3. Print as usual.
+
+The preview shows the cut mark too, so what you see is what gets printed.
+
+### Notes
+
+- The setting lives on the label (`LabelSettings.cutMark`) and round-trips through save/load — useful for label designs you reprint often.
+- Applies to every print path (`/api/print`, `/api/preview`, `/api/batch-print`), gated by `settings.cutMark`. Off by default; existing labels are unaffected.
+
+---

--- a/.github/release-notes/v1.6.1.md
+++ b/.github/release-notes/v1.6.1.md
@@ -16,11 +16,11 @@ Pull the tape out of the printer, follow the dotted columns with scissors, done.
 2. Check **Cut mark** (next to Copies / Pause).
 3. Print as usual.
 
-The preview shows the cut mark too, so what you see is what gets printed.
-
 ### Notes
 
+- **Batch only.** The cut mark is painted into the trailing margin of every batch label except the last — single-label `/api/print` and the `/api/preview` thumbnail aren't modified (a single label has nothing to be between).
+- **Zero extra tape.** Each label's bitmap already carries ~14 mm of trailing margin; the dotted column lives inside that gap, so enabling the setting doesn't lengthen the print.
 - The setting lives on the label (`LabelSettings.cutMark`) and round-trips through save/load — useful for label designs you reprint often.
-- Applies to every print path (`/api/print`, `/api/preview`, `/api/batch-print`), gated by `settings.cutMark`. Off by default; existing labels are unaffected.
+- Off by default; existing labels are unaffected.
 
 ---

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ You can fight against AI usage or learn to embrace it as a new way of working. I
 - **Multi-printer support** -- automatically detects all connected DYMO printers; select specific printer when multiple are available
 - **Virtual printers** -- configure virtual printers that save labels as PNG images, JSON data, or both (great for testing, archiving, and development)
 - **Batch print** -- print multiple labels with variable content using `:varname:` placeholders, with a table to fill in values per row, configurable copies and pause time, SSE progress streaming, and cancellation support
+- **Cut mark** -- optional dotted column painted into the trailing margin between batch labels so you can tear/cut between them; uses the existing inter-label gap, no extra tape
 - **Save/load labels** -- export label designs to JSON files and load them back, with embedded image data and batch configuration for portability
 - **Print via labelle** -- sends labels to the printer using the labelle Python library over USB
 - **USB power save** -- optionally power off the printer's USB port via uhubctl when the server is idle, and power it back on automatically when the page is opened (opt-in via `USB_POWER_SAVE=true`)

--- a/client/src/components/BatchPanel.tsx
+++ b/client/src/components/BatchPanel.tsx
@@ -29,6 +29,8 @@ function EyeIcon({ active }: { active: boolean }) {
 export function BatchPanel() {
   const widgets = useLabelStore((s) => s.widgets);
   const batch = useLabelStore((s) => s.batch);
+  const settings = useLabelStore((s) => s.settings);
+  const updateSettings = useLabelStore((s) => s.updateSettings);
   const updateBatch = useLabelStore((s) => s.updateBatch);
   const setBatchRow = useLabelStore((s) => s.setBatchRow);
   const addBatchRow = useLabelStore((s) => s.addBatchRow);
@@ -226,7 +228,7 @@ export function BatchPanel() {
           </>
         )}
 
-        <div className="flex flex-wrap gap-4 pt-1 border-t border-gray-100">
+        <div className="flex flex-wrap items-center gap-4 pt-1 border-t border-gray-100">
           <label className="flex items-center gap-1.5">
             <span className="text-gray-600">Copies</span>
             <input
@@ -251,6 +253,17 @@ export function BatchPanel() {
               onChange={(e) => setPauseInput(e.target.value)}
               onBlur={commitPause}
             />
+          </label>
+          <label
+            className="flex items-center gap-1.5"
+            title="Print a dotted line on the right edge of each label so you can tear/cut between them"
+          >
+            <input
+              type="checkbox"
+              checked={settings.cutMark}
+              onChange={(e) => updateSettings({ cutMark: e.target.checked })}
+            />
+            <span className="text-gray-600">Cut mark</span>
           </label>
         </div>
       </div>

--- a/client/src/components/SettingsBar.test.tsx
+++ b/client/src/components/SettingsBar.test.tsx
@@ -42,6 +42,7 @@ beforeEach(() => {
       foregroundColor: "black",
       backgroundColor: "white",
       showMargins: false,
+      cutMark: false,
     },
   });
 });

--- a/client/src/lib/api.test.ts
+++ b/client/src/lib/api.test.ts
@@ -33,6 +33,7 @@ const sampleSettings: LabelSettings = {
   foregroundColor: "black",
   backgroundColor: "white",
   showMargins: false,
+  cutMark: false,
 };
 
 describe("fetchPrinters", () => {

--- a/client/src/state/useLabelStore.test.ts
+++ b/client/src/state/useLabelStore.test.ts
@@ -119,6 +119,7 @@ describe("Settings", () => {
       foregroundColor: "black",
       backgroundColor: "white",
       showMargins: false,
+      cutMark: false,
     });
   });
 });
@@ -146,6 +147,7 @@ describe("Load", () => {
       foregroundColor: "blue",
       backgroundColor: "yellow",
       showMargins: true,
+      cutMark: false,
     };
 
     useLabelStore.getState().loadLabel(widgets, settings);

--- a/client/src/state/useLabelStore.ts
+++ b/client/src/state/useLabelStore.ts
@@ -73,6 +73,7 @@ export const useLabelStore = create<LabelStore>((set) => ({
     foregroundColor: "black",
     backgroundColor: "white",
     showMargins: false,
+    cutMark: false,
   },
 
   availablePrinters: [],

--- a/client/src/types/label.ts
+++ b/client/src/types/label.ts
@@ -100,5 +100,10 @@ export interface LabelSettings {
   foregroundColor: LabelColor;
   backgroundColor: LabelColor;
   showMargins: boolean;
+  // Print a dotted vertical line on the right edge of each batch-printed
+  // label so the user can tear/cut between them. Ignored in single-label
+  // mode (visible only in BatchPanel) but stored here so it round-trips
+  // through save/load with the rest of the label settings.
+  cutMark: boolean;
   printerId?: string; // Optional printer ID for multi-printer setups
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labelle-web",
-  "version": "1.6.0",
+  "version": "1.6.1-dev",
   "private": true,
   "description": "Web interface for labelle DYMO label printers",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labelle-web",
-  "version": "1.6.1-dev",
+  "version": "1.6.1",
   "private": true,
   "description": "Web interface for labelle DYMO label printers",
   "scripts": {

--- a/server/app.py
+++ b/server/app.py
@@ -19,8 +19,8 @@ from werkzeug.utils import secure_filename
 
 import power_save
 import usb_power
-from label_builder import preview_label
-from printer_service import list_printers, print_label
+from label_builder import paint_cut_mark_in_trailing_margin, preview_label, render_payload
+from printer_service import list_printers, print_bitmap, print_label
 
 # Seconds to wait after power-on before reading status, so the device has
 # time to re-enumerate on the USB bus.
@@ -91,22 +91,20 @@ def _track_activity_and_wake_printer():
 power_save.start()
 
 
-def _print_cut_mark(settings: dict, printer_id: str | None) -> None:
-    """Print a dotted cut-mark strip as a separate label.
+def _print_label_with_cut_mark(
+    widgets: list, settings: dict, printer_id: str | None
+) -> None:
+    """Print a label with a cut mark painted into its trailing margin.
 
-    Issued between successive labels in a batch so the dots sit outside
-    each label's margins (the leader/trailer margins of the cut-mark
-    strip and the adjacent labels form the natural cut zone). marginPx
-    and minLengthMm are zeroed so the strip is just the dotted column
-    plus the printer's unavoidable physical margins.
+    Renders the label normally then injects the dotted column into the
+    already-allocated trailing blank — no extra tape consumed, dot
+    sits in the middle of what would otherwise be the inter-label gap.
     """
-    cut_settings = {**settings, "marginPx": 0, "minLengthMm": 0}
-    print_label(
-        [{"type": "cutMark"}],
-        cut_settings,
-        upload_dir=UPLOAD_DIR,
-        printer_id=printer_id,
+    bitmap = render_payload(widgets, settings, upload_dir=UPLOAD_DIR)
+    paint_cut_mark_in_trailing_margin(
+        bitmap, margin_px=settings.get("marginPx", 56)
     )
+    print_bitmap(bitmap, settings, printer_id=printer_id)
 
 
 @app.route("/api/print", methods=["POST"])
@@ -414,14 +412,16 @@ def api_batch_print():
                 power_save.record_activity()
 
                 try:
-                    # Cut mark between successive labels (not before the
-                    # first, not after the last) — sits in its own tape
-                    # strip so the labeler margins of each side form the
-                    # natural cut zone.
-                    if idx > 0 and settings.get("cutMark"):
-                        _print_cut_mark(settings, printer_id)
                     substituted = _substitute_widgets(widgets, row_values)
-                    print_label(substituted, settings, upload_dir=UPLOAD_DIR, printer_id=printer_id)
+                    # Paint the cut mark into the trailing margin of every
+                    # label except the last — that gap is already there
+                    # (labelle builds ~14 mm of trailing blank into each
+                    # label's bitmap), so the dot lands in its centre with
+                    # zero extra tape.
+                    if idx < total - 1 and settings.get("cutMark"):
+                        _print_label_with_cut_mark(substituted, settings, printer_id)
+                    else:
+                        print_label(substituted, settings, upload_dir=UPLOAD_DIR, printer_id=printer_id)
                 except Exception as e:
                     traceback.print_exc()
                     yield f"data: {json.dumps({'event': 'error', 'index': idx, 'message': str(e)})}\n\n"

--- a/server/app.py
+++ b/server/app.py
@@ -91,12 +91,22 @@ def _track_activity_and_wake_printer():
 power_save.start()
 
 
-def _with_cut_mark(widgets: list, settings: dict) -> list:
-    """Append a dotted cut-mark widget on the right edge if settings.cutMark
-    is true. Keeps the original list unmodified."""
-    if settings.get("cutMark"):
-        return widgets + [{"type": "cutMark"}]
-    return widgets
+def _print_cut_mark(settings: dict, printer_id: str | None) -> None:
+    """Print a dotted cut-mark strip as a separate label.
+
+    Issued between successive labels in a batch so the dots sit outside
+    each label's margins (the leader/trailer margins of the cut-mark
+    strip and the adjacent labels form the natural cut zone). marginPx
+    and minLengthMm are zeroed so the strip is just the dotted column
+    plus the printer's unavoidable physical margins.
+    """
+    cut_settings = {**settings, "marginPx": 0, "minLengthMm": 0}
+    print_label(
+        [{"type": "cutMark"}],
+        cut_settings,
+        upload_dir=UPLOAD_DIR,
+        printer_id=printer_id,
+    )
 
 
 @app.route("/api/print", methods=["POST"])
@@ -110,7 +120,7 @@ def api_print():
         return jsonify(status="error", message="No widgets provided"), 400
 
     try:
-        print_label(_with_cut_mark(widgets, settings), settings, upload_dir=UPLOAD_DIR, printer_id=printer_id)
+        print_label(widgets, settings, upload_dir=UPLOAD_DIR, printer_id=printer_id)
         return jsonify(status="success", message="Label sent to printer.")
     except Exception as e:
         traceback.print_exc()
@@ -127,7 +137,7 @@ def api_preview():
         return jsonify(status="error", message="No widgets provided"), 400
 
     try:
-        png_bytes = preview_label(_with_cut_mark(widgets, settings), settings, upload_dir=UPLOAD_DIR)
+        png_bytes = preview_label(widgets, settings, upload_dir=UPLOAD_DIR)
         return app.response_class(png_bytes, mimetype="image/png")
     except Exception as e:
         traceback.print_exc()
@@ -404,8 +414,14 @@ def api_batch_print():
                 power_save.record_activity()
 
                 try:
+                    # Cut mark between successive labels (not before the
+                    # first, not after the last) — sits in its own tape
+                    # strip so the labeler margins of each side form the
+                    # natural cut zone.
+                    if idx > 0 and settings.get("cutMark"):
+                        _print_cut_mark(settings, printer_id)
                     substituted = _substitute_widgets(widgets, row_values)
-                    print_label(_with_cut_mark(substituted, settings), settings, upload_dir=UPLOAD_DIR, printer_id=printer_id)
+                    print_label(substituted, settings, upload_dir=UPLOAD_DIR, printer_id=printer_id)
                 except Exception as e:
                     traceback.print_exc()
                     yield f"data: {json.dumps({'event': 'error', 'index': idx, 'message': str(e)})}\n\n"

--- a/server/app.py
+++ b/server/app.py
@@ -91,6 +91,14 @@ def _track_activity_and_wake_printer():
 power_save.start()
 
 
+def _with_cut_mark(widgets: list, settings: dict) -> list:
+    """Append a dotted cut-mark widget on the right edge if settings.cutMark
+    is true. Keeps the original list unmodified."""
+    if settings.get("cutMark"):
+        return widgets + [{"type": "cutMark"}]
+    return widgets
+
+
 @app.route("/api/print", methods=["POST"])
 def api_print():
     data = request.get_json(silent=True) or {}
@@ -102,7 +110,7 @@ def api_print():
         return jsonify(status="error", message="No widgets provided"), 400
 
     try:
-        print_label(widgets, settings, upload_dir=UPLOAD_DIR, printer_id=printer_id)
+        print_label(_with_cut_mark(widgets, settings), settings, upload_dir=UPLOAD_DIR, printer_id=printer_id)
         return jsonify(status="success", message="Label sent to printer.")
     except Exception as e:
         traceback.print_exc()
@@ -119,7 +127,7 @@ def api_preview():
         return jsonify(status="error", message="No widgets provided"), 400
 
     try:
-        png_bytes = preview_label(widgets, settings, upload_dir=UPLOAD_DIR)
+        png_bytes = preview_label(_with_cut_mark(widgets, settings), settings, upload_dir=UPLOAD_DIR)
         return app.response_class(png_bytes, mimetype="image/png")
     except Exception as e:
         traceback.print_exc()
@@ -397,7 +405,7 @@ def api_batch_print():
 
                 try:
                     substituted = _substitute_widgets(widgets, row_values)
-                    print_label(substituted, settings, upload_dir=UPLOAD_DIR, printer_id=printer_id)
+                    print_label(_with_cut_mark(substituted, settings), settings, upload_dir=UPLOAD_DIR, printer_id=printer_id)
                 except Exception as e:
                     traceback.print_exc()
                     yield f"data: {json.dumps({'event': 'error', 'index': idx, 'message': str(e)})}\n\n"

--- a/server/app.py
+++ b/server/app.py
@@ -15,6 +15,7 @@ load_dotenv(os.path.join(os.path.dirname(__file__), "..", ".env"))
 
 from flask import Flask, Response, jsonify, request, send_from_directory
 from flask_cors import CORS
+from labelle.lib.constants import DEFAULT_MARGIN_PX
 from werkzeug.utils import secure_filename
 
 import power_save
@@ -102,9 +103,9 @@ def _print_label_with_cut_mark(
     """
     bitmap = render_payload(widgets, settings, upload_dir=UPLOAD_DIR)
     paint_cut_mark_in_trailing_margin(
-        bitmap, margin_px=settings.get("marginPx", 56)
+        bitmap, margin_px=settings.get("marginPx", DEFAULT_MARGIN_PX)
     )
-    print_bitmap(bitmap, settings, printer_id=printer_id)
+    print_bitmap(bitmap, settings, printer_id=printer_id, widgets=widgets)
 
 
 @app.route("/api/print", methods=["POST"])

--- a/server/label_builder.py
+++ b/server/label_builder.py
@@ -32,26 +32,45 @@ def mm_to_payload_px(mm: float, margin: float) -> float:
 
 
 # Cut-mark pattern. CUT_MARK_ON pixels on, CUT_MARK_OFF off, repeated for the
-# tape's full height. A column of dotted pixels printed on the right edge of
-# each label so the user can tear/cut between batch-printed labels.
+# tape's full height. A column of dotted pixels printed on its own short tape
+# strip between batch-printed labels so the user can tear/cut between them.
 CUT_MARK_ON = 1
 CUT_MARK_OFF = 2
+CUT_MARK_WIDTH_PX = 1
 
 
-class CutMarkRenderEngine(RenderEngine):
-    """A 1-pixel-wide column of dotted pixels for tear/cut guidance."""
+def paint_cut_mark_in_trailing_margin(bitmap: Image.Image, margin_px: int) -> None:
+    """Paint a dotted column INTO an already-rendered label bitmap, in the
+    middle of its trailing-margin zone. Mutates the bitmap in place.
 
-    def render(self, context: RenderContext) -> Image.Image:
-        height = context.height_px
-        # Mode "1": 0 = ink (printed), 1 = no ink. Start fully unprinted.
-        img = Image.new("1", (1, height), 1)
-        pixels = img.load()
-        step = CUT_MARK_ON + CUT_MARK_OFF
-        for y in range(0, height, step):
-            for dy in range(CUT_MARK_ON):
-                if y + dy < height:
-                    pixels[0, y + dy] = 0
-        return img
+    Why this design: each labelle label bitmap is built as
+    `[content][~14 mm trailing margin]` (visible margin + labeler-margin
+    compensation). The next label in a batch has no leading blank
+    (paste offset clips its first column). So adding a separate
+    cut-mark print between labels lands the dots flush against the
+    next label's content edge — visually flush, not centered.
+
+    Painting INTO the trailing zone puts the dotted column inside the
+    14 mm that's already there, no extra tape consumed, and the
+    dot sits in the middle of the visible inter-label gap.
+
+    Position: width - margin_px, which is roughly the centre of the
+    right trailing-margin zone for a typical centre-justified label.
+
+    Labelle payload convention: mode "1" with 1 = ink, 0 = no ink.
+    """
+    width, height = bitmap.size
+    x = max(0, width - margin_px)
+    if x >= width:
+        return
+    pixels = bitmap.load()
+    step = CUT_MARK_ON + CUT_MARK_OFF
+    for y in range(0, height, step):
+        for dy in range(CUT_MARK_ON):
+            if y + dy < height:
+                for ox in range(CUT_MARK_WIDTH_PX):
+                    if x + ox < width:
+                        pixels[x + ox, y + dy] = 1
 
 
 def _build_render_engines(
@@ -112,9 +131,6 @@ def _build_render_engines(
                 picture_path = os.path.join(upload_dir, filename)
                 if os.path.isfile(picture_path):
                     engines.append(PictureRenderEngine(picture_path=picture_path))
-
-        elif widget_type == "cutMark":
-            engines.append(CutMarkRenderEngine())
 
     return engines
 

--- a/server/label_builder.py
+++ b/server/label_builder.py
@@ -61,8 +61,11 @@ def paint_cut_mark_in_trailing_margin(bitmap: Image.Image, margin_px: int) -> No
     Labelle payload convention: mode "1" with 1 = ink, 0 = no ink.
     """
     width, height = bitmap.size
-    x = max(0, width - margin_px)
-    if x >= width:
+    x = width - margin_px
+    # If the bitmap is narrower than the margin (degenerate input), there is
+    # no trailing-margin zone to paint into — skip rather than landing the
+    # dots in the content area.
+    if x < 0 or x >= width:
         return
     pixels = bitmap.load()
     step = CUT_MARK_ON + CUT_MARK_OFF

--- a/server/label_builder.py
+++ b/server/label_builder.py
@@ -31,6 +31,29 @@ def mm_to_payload_px(mm: float, margin: float) -> float:
     return max(0, (mm * PIXELS_PER_MM) - margin * 2)
 
 
+# Cut-mark pattern. CUT_MARK_ON pixels on, CUT_MARK_OFF off, repeated for the
+# tape's full height. A column of dotted pixels printed on the right edge of
+# each label so the user can tear/cut between batch-printed labels.
+CUT_MARK_ON = 1
+CUT_MARK_OFF = 2
+
+
+class CutMarkRenderEngine(RenderEngine):
+    """A 1-pixel-wide column of dotted pixels for tear/cut guidance."""
+
+    def render(self, context: RenderContext) -> Image.Image:
+        height = context.height_px
+        # Mode "1": 0 = ink (printed), 1 = no ink. Start fully unprinted.
+        img = Image.new("1", (1, height), 1)
+        pixels = img.load()
+        step = CUT_MARK_ON + CUT_MARK_OFF
+        for y in range(0, height, step):
+            for dy in range(CUT_MARK_ON):
+                if y + dy < height:
+                    pixels[0, y + dy] = 0
+        return img
+
+
 def _build_render_engines(
     widgets: list[dict], upload_dir: str = "",
 ) -> list[RenderEngine]:
@@ -89,6 +112,9 @@ def _build_render_engines(
                 picture_path = os.path.join(upload_dir, filename)
                 if os.path.isfile(picture_path):
                     engines.append(PictureRenderEngine(picture_path=picture_path))
+
+        elif widget_type == "cutMark":
+            engines.append(CutMarkRenderEngine())
 
     return engines
 

--- a/server/label_builder.py
+++ b/server/label_builder.py
@@ -32,8 +32,9 @@ def mm_to_payload_px(mm: float, margin: float) -> float:
 
 
 # Cut-mark pattern. CUT_MARK_ON pixels on, CUT_MARK_OFF off, repeated for the
-# tape's full height. A column of dotted pixels printed on its own short tape
-# strip between batch-printed labels so the user can tear/cut between them.
+# tape's full height. A column of dotted pixels painted into the trailing
+# margin of each batch label (except the last) so the user can tear/cut
+# between them. See paint_cut_mark_in_trailing_margin below for placement.
 CUT_MARK_ON = 1
 CUT_MARK_OFF = 2
 CUT_MARK_WIDTH_PX = 1

--- a/server/label_builder.py
+++ b/server/label_builder.py
@@ -61,7 +61,13 @@ def paint_cut_mark_in_trailing_margin(bitmap: Image.Image, margin_px: int) -> No
     Labelle payload convention: mode "1" with 1 = ink, 0 = no ink.
     """
     width, height = bitmap.size
-    x = width - margin_px
+    # margin_px == 0 is valid in the UI (SettingsBar allows it). Treat it
+    # as "paint at the rightmost column" so the cut mark still appears
+    # rather than silently doing nothing.
+    if margin_px <= 0:
+        x = width - CUT_MARK_WIDTH_PX
+    else:
+        x = width - margin_px
     # If the bitmap is narrower than the margin (degenerate input), there is
     # no trailing-margin zone to paint into — skip rather than landing the
     # dots in the content area.

--- a/server/printer_service.py
+++ b/server/printer_service.py
@@ -1,5 +1,7 @@
 import traceback
 
+from PIL import Image
+
 from labelle.lib.devices.device_manager import DeviceManager
 from labelle.lib.devices.dymo_labeler import DymoLabeler
 
@@ -133,4 +135,49 @@ def print_label(
         device=device,
     )
     bitmap = render_payload(widgets, settings, upload_dir)
+    dymo_labeler.print(bitmap)
+
+
+def print_bitmap(
+    bitmap: Image.Image, settings: dict, printer_id: str | None = None
+) -> None:
+    """Send a pre-rendered mode-"1" bitmap directly to the printer.
+
+    Used for the cut-mark strip where MarginsRenderEngine's labeler-margin
+    offset compensation would clip a narrow payload off-canvas. For virtual
+    printers, the bitmap is saved as-is via save_preview (inverted to the
+    intuitive black-on-white form first).
+    """
+    # Virtual printer
+    if printer_id and printer_id.startswith("virtual:"):
+        virtual_printer = _find_virtual_printer(printer_id)
+        # Bitmap is mode "1" with 1=ink. Convert to a viewable PNG where
+        # ink shows as black on white tape.
+        viewable = bitmap.point(lambda v: 0 if v else 255, mode="L").convert("1")
+        virtual_printer.save_preview(viewable)
+        return
+
+    # Real USB printer
+    try:
+        device_manager = DeviceManager()
+        device_manager.scan()
+        if printer_id:
+            matching = [d for d in device_manager.devices if d.usb_id == printer_id]
+            if not matching:
+                raise ValueError(f"Printer not found: {printer_id}")
+            device = matching[0]
+        else:
+            device = device_manager.find_and_select_device()
+    except Exception:
+        if printer_id:
+            raise
+        # No USB printer available — silently skip the cut mark rather
+        # than crashing the surrounding batch.
+        return
+
+    device.setup()
+    dymo_labeler = DymoLabeler(
+        tape_size_mm=settings.get("tapeSizeMm", 12),
+        device=device,
+    )
     dymo_labeler.print(bitmap)

--- a/server/printer_service.py
+++ b/server/printer_service.py
@@ -138,26 +138,56 @@ def print_label(
     dymo_labeler.print(bitmap)
 
 
-def print_bitmap(
-    bitmap: Image.Image, settings: dict, printer_id: str | None = None
-) -> None:
-    """Send a pre-rendered mode-"1" bitmap directly to the printer.
+def _bitmap_to_viewable(bitmap: Image.Image) -> Image.Image:
+    """Convert a labelle-convention mode-"1" payload (1 = ink) to a viewable
+    black-on-white image suitable for a virtual printer's PNG save."""
+    return bitmap.point(lambda v: 0 if v else 255, mode="L").convert("1")
 
-    Used for the cut-mark strip where MarginsRenderEngine's labeler-margin
-    offset compensation would clip a narrow payload off-canvas. For virtual
-    printers, the bitmap is saved as-is via save_preview (inverted to the
-    intuitive black-on-white form first).
+
+def _fallback_to_virtual_bitmap(
+    bitmap: Image.Image, widgets: list[dict], settings: dict
+) -> None:
+    """Print a pre-rendered bitmap to the first configured virtual printer."""
+    virtual_printers_config = get_virtual_printers()
+    if not virtual_printers_config:
+        raise ValueError(
+            "No printers available (no USB printers found and no virtual printers configured)"
+        )
+    config = virtual_printers_config[0]
+    vp = VirtualPrinter(
+        config["name"], config["path"], output_mode=config.get("output", "image")
+    )
+    vp.save(_bitmap_to_viewable(bitmap), widgets, settings)
+
+
+def print_bitmap(
+    bitmap: Image.Image,
+    settings: dict,
+    printer_id: str | None = None,
+    widgets: list[dict] | None = None,
+) -> None:
+    """Send a pre-rendered mode-"1" bitmap to the printer.
+
+    Used by callers that need to post-process a rendered payload before
+    sending it (the cut-mark path mutates the bitmap to inject a dotted
+    column into the trailing margin), so going back through
+    `render_payload()` inside `print_label()` would discard that change.
+
+    Behaviour mirrors `print_label()` apart from skipping the render step:
+    virtual printers respect their configured `output_mode` (image / json
+    / both) and an auto-select USB failure falls back to the first
+    virtual printer rather than silently dropping the print.
     """
+    widgets = widgets or []
+
     # Virtual printer
     if printer_id and printer_id.startswith("virtual:"):
         virtual_printer = _find_virtual_printer(printer_id)
-        # Bitmap is mode "1" with 1=ink. Convert to a viewable PNG where
-        # ink shows as black on white tape.
-        viewable = bitmap.point(lambda v: 0 if v else 255, mode="L").convert("1")
-        virtual_printer.save_preview(viewable)
+        virtual_printer.save(_bitmap_to_viewable(bitmap), widgets, settings)
         return
 
-    # Real USB printer
+    # Try real USB printer
+    device = None
     try:
         device_manager = DeviceManager()
         device_manager.scan()
@@ -171,8 +201,10 @@ def print_bitmap(
     except Exception:
         if printer_id:
             raise
-        # No USB printer available — silently skip the cut mark rather
-        # than crashing the surrounding batch.
+        # Auto-select failed: fall back to the first virtual printer rather
+        # than silently swallowing the print and emitting a misleading
+        # `printed` SSE event upstream.
+        _fallback_to_virtual_bitmap(bitmap, widgets, settings)
         return
 
     device.setup()

--- a/server/tests/test_label_builder_cut_mark.py
+++ b/server/tests/test_label_builder_cut_mark.py
@@ -1,0 +1,73 @@
+"""Tests for the cut-mark trailing-margin painter.
+
+The dot lives inside each batch label's existing trailing margin so no
+extra tape is consumed; placement is `bitmap.width - margin_px`. These
+tests lock in that contract.
+"""
+
+from PIL import Image
+
+from label_builder import (
+    CUT_MARK_OFF,
+    CUT_MARK_ON,
+    CUT_MARK_WIDTH_PX,
+    paint_cut_mark_in_trailing_margin,
+)
+
+
+def _make_blank_payload(width: int = 200, height: int = 64) -> Image.Image:
+    """Mode-"1" bitmap with everything = 0 (no ink, labelle convention)."""
+    return Image.new("1", (width, height), 0)
+
+
+class TestPaintCutMarkInTrailingMargin:
+    def test_paints_at_width_minus_margin(self):
+        bm = _make_blank_payload(width=200, height=64)
+        paint_cut_mark_in_trailing_margin(bm, margin_px=56)
+
+        # All ink should be on the same column.
+        ink_cols = {x for x in range(bm.width) for y in range(bm.height) if bm.getpixel((x, y))}
+        assert ink_cols == set(range(200 - 56, 200 - 56 + CUT_MARK_WIDTH_PX))
+
+    def test_pattern_is_one_on_two_off(self):
+        bm = _make_blank_payload(width=200, height=64)
+        paint_cut_mark_in_trailing_margin(bm, margin_px=56)
+
+        x = 200 - 56
+        ink_rows = [y for y in range(bm.height) if bm.getpixel((x, y))]
+        # 1 on, 2 off → rows 0, 3, 6, ..., 63 (every 3rd row)
+        expected = list(range(0, bm.height, CUT_MARK_ON + CUT_MARK_OFF))
+        assert ink_rows == expected
+
+    def test_does_nothing_outside_trailing_margin(self):
+        """Content area (x < width - margin_px) should stay untouched."""
+        bm = _make_blank_payload(width=200, height=64)
+        paint_cut_mark_in_trailing_margin(bm, margin_px=56)
+
+        for x in range(0, 200 - 56):
+            for y in range(bm.height):
+                assert bm.getpixel((x, y)) == 0, f"unexpected ink at ({x}, {y})"
+
+    def test_preserves_existing_ink(self):
+        """Painting the cut mark must not erase the label's content."""
+        bm = _make_blank_payload(width=200, height=64)
+        # Plant some "content" ink in the leading half
+        for x in range(10, 30):
+            for y in range(20, 40):
+                bm.putpixel((x, y), 1)
+
+        paint_cut_mark_in_trailing_margin(bm, margin_px=56)
+
+        for x in range(10, 30):
+            for y in range(20, 40):
+                assert bm.getpixel((x, y)) == 1, f"content erased at ({x}, {y})"
+
+    def test_no_op_when_margin_larger_than_bitmap(self):
+        """A degenerate input shouldn't crash or write out of bounds."""
+        bm = _make_blank_payload(width=10, height=64)
+        paint_cut_mark_in_trailing_margin(bm, margin_px=999)
+
+        # Bitmap should still be blank — no ink anywhere.
+        for x in range(bm.width):
+            for y in range(bm.height):
+                assert bm.getpixel((x, y)) == 0

--- a/server/tests/test_label_builder_cut_mark.py
+++ b/server/tests/test_label_builder_cut_mark.py
@@ -71,3 +71,12 @@ class TestPaintCutMarkInTrailingMargin:
         for x in range(bm.width):
             for y in range(bm.height):
                 assert bm.getpixel((x, y)) == 0
+
+    def test_margin_zero_paints_at_rightmost_column(self):
+        """margin_px=0 is valid in the UI; paint at the rightmost column
+        rather than silently doing nothing."""
+        bm = _make_blank_payload(width=200, height=64)
+        paint_cut_mark_in_trailing_margin(bm, margin_px=0)
+
+        ink_cols = {x for x in range(bm.width) for y in range(bm.height) if bm.getpixel((x, y))}
+        assert ink_cols == set(range(200 - CUT_MARK_WIDTH_PX, 200))


### PR DESCRIPTION
## Summary

Adds an opt-in cut mark — a 1-pixel-wide dotted vertical line painted into the trailing margin of every batch label except the last, so users can tear/cut between continuously printed labels.

## What it looks like

\`\`\`
[ label A ┊ ][ label B ┊ ][ label C ]
\`\`\`

The dot lives inside the ~14 mm of trailing margin that labelle already builds into every label's bitmap, so enabling the setting **doesn't lengthen the print**. Pixel pattern: 1 on, 2 off, repeated for the tape's full height.

## Scope

- **Batch only.** Painted into the trailing margin of label N for every N < last in a batch.
- Single-label \`/api/print\` and the \`/api/preview\` thumbnail are not modified — a single label has no \"next\" to mark.

## Usage

- **Cut mark** checkbox in the Batch Print panel, next to Copies / Pause.
- Setting persists in \`LabelSettings.cutMark\` so it round-trips through save/load.

## Implementation

- \`label_builder.paint_cut_mark_in_trailing_margin(bitmap, margin_px)\` — in-place mutator that draws the dotted column at \`x = width - margin_px\` of an already-rendered mode-\"1\" payload.
- \`printer_service.print_bitmap(bitmap, settings, printer_id, widgets)\` — sends a pre-rendered bitmap to the printer. Mirrors \`print_label()\`'s virtual / fallback semantics (respects \`output_mode\`, falls back to first virtual printer on USB auto-select failure).
- Batch loop in \`server/app.py\`: for \`idx < total - 1 && settings.cutMark\`, render → paint → \`print_bitmap\`; otherwise the normal \`print_label\` path.

### Earlier dead-end designs

The first attempt printed the cut mark as a separate zero-margin \"label\" between successive prints. Two problems caught on hardware:

1. labelle's \`MarginsRenderEngine\` subtracts \`labeler_horizontal_margin_px\` (~57 px on the DYMO PnP) from the paste offset; a 1–3 px payload ended up pasted off-canvas and nothing printed (confirmed via diagnostic PNG).
2. After bypassing \`MarginsRenderEngine\` directly to print the bitmap, the dot landed flush against the next label's content edge — labelle bakes the gap into label N's bitmap (trailing margin) and label N+1 has no leading blank.

Final design (this PR) sidesteps both by painting the dot into label N's already-existing trailing margin instead of issuing a separate print.

## Version

\`1.6.1\` (PATCH — small additive feature). The release workflow auto-tags and builds the Docker image on merge.

## Test plan

- [x] Server tests pass: 211 pytest tests (5 new in \`test_label_builder_cut_mark.py\` covering placement, pattern, content-area preservation, and degenerate-input no-op)
- [x] Client tests pass: 52 vitest
- [x] Docker build + Docker smoke CI green
- [x] Hardware test on hector with the actual Dymo printer — 2-label batch with cut mark on prints a centred dotted line between labels, no extra tape