### PR TITLE
feat: persist per-printer label settings (tape size, colors) across visits

### DIFF
--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -5,6 +5,13 @@ import type {
   PowerStatus,
 } from "../types/label";
 
+/** Per-printer persisted settings subset returned by the API. */
+export interface PersistedPrinterSettings {
+  tapeSizeMm?: number;
+  foregroundColor?: string;
+  backgroundColor?: string;
+}
+
 interface PrintResponse {
   status: string;
   message: string;
@@ -188,4 +195,37 @@ export async function powerOn(): Promise<PowerStatus> {
 export async function powerOff(): Promise<PowerStatus> {
   const res = await fetch("/api/power/off", { method: "POST" });
   return _readPowerResponse(res);
+}
+
+/**
+ * Fetch per-printer label settings saved from a previous session.
+ * Returns null when no settings have been saved for this printer.
+ */
+export async function fetchPrinterSettings(
+  printerId: string,
+): Promise<PersistedPrinterSettings | null> {
+  // URL-encode the printer ID so special characters in USB IDs don't break routing.
+  const res = await fetch(
+    `/api/printers/${encodeURIComponent(printerId)}/settings`,
+  );
+  if (!res.ok) {
+    console.warn("Failed to fetch printer settings:", res.status);
+    return null;
+  }
+  return res.json() as Promise<PersistedPrinterSettings | null>;
+}
+
+/**
+ * Save label settings for the currently-selected printer.
+ * Only tapeSizeMm, foregroundColor, and backgroundColor are persisted.
+ */
+export async function savePrinterSettings(
+  printerId: string,
+  settings: PersistedPrinterSettings,
+): Promise<void> {
+  await fetch(`/api/printers/${encodeURIComponent(printerId)}/settings`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(settings),
+  });
 }

--- a/client/src/state/useLabelStore.ts
+++ b/client/src/state/useLabelStore.ts
@@ -12,6 +12,7 @@ import type {
 } from "../types/label";
 import { DEFAULT_MARGIN_PX, DEFAULT_FONT_SCALE } from "../lib/constants";
 import { detectVariables } from "../lib/variables";
+import { fetchPrinterSettings, savePrinterSettings } from "../lib/api";
 
 function newBatchRow(values: Record<string, string> = {}) {
   return { id: uuidv4(), values };
@@ -52,7 +53,7 @@ interface LabelStore {
   ) => void;
 }
 
-export const useLabelStore = create<LabelStore>((set) => ({
+export const useLabelStore = create<LabelStore>((set, get) => ({
   widgets: [
     {
       id: uuidv4(),
@@ -218,10 +219,54 @@ export const useLabelStore = create<LabelStore>((set) => ({
       return { widgets };
     }),
 
-  updateSettings: (patch) =>
-    set((s) => ({ settings: { ...s.settings, ...patch } })),
+  updateSettings: (patch) => {
+    const prevPrinterId = get().settings.printerId;
+    set((s) => ({ settings: { ...s.settings, ...patch } }));
 
-  setAvailablePrinters: (printers) => set({ availablePrinters: printers }),
+    const state = get();
+    const printerId = state.settings.printerId;
+
+    // When the user switches to a different printer, load its saved
+    // settings (tape size, colors) from the previous session.
+    if (printerId && printerId !== prevPrinterId) {
+      _loadAndApplyPrinterSettings(printerId, set);
+    }
+
+    // Persist per-printer settings when the user changes tape size or
+    // colors while a printer is actively selected.
+    if (!printerId) return;
+
+    const persistedFields = [
+      "tapeSizeMm",
+      "foregroundColor",
+      "backgroundColor",
+    ] as const;
+    const hasPersistedChange = persistedFields.some(
+      (k) => k in patch,
+    );
+    if (!hasPersistedChange) return;
+
+    const { tapeSizeMm, foregroundColor, backgroundColor } = state.settings;
+    savePrinterSettings(printerId, {
+      tapeSizeMm,
+      foregroundColor,
+      backgroundColor,
+    }).catch((err) => {
+      console.warn("Failed to persist printer settings:", err);
+    });
+  },
+
+  setAvailablePrinters: (printers) => {
+    set({ availablePrinters: printers });
+
+    // If a printer was previously selected and it still exists, load
+    // its saved settings. This covers the case where the printer list
+    // arrives after the UI has already mounted (e.g. on refresh).
+    const printerId = get().settings.printerId;
+    if (printerId && printers.some((p) => p.id === printerId)) {
+      _loadAndApplyPrinterSettings(printerId, set);
+    }
+  },
 
   updateBatch: (patch) =>
     set((s) => ({ batch: { ...s.batch, ...patch } })),
@@ -263,3 +308,40 @@ export const useLabelStore = create<LabelStore>((set) => ({
   loadLabel: (widgets, settings, batch) =>
     set({ widgets, settings, batch: batch ?? defaultBatch() }),
 }));
+
+/**
+ * Fetch saved printer settings and apply them to the current label
+ * settings. Silently does nothing on failure — the user's current
+ * settings are left untouched.
+ */
+function _loadAndApplyPrinterSettings(
+  printerId: string,
+  set: (
+    partial:
+      | LabelStore
+      | Partial<LabelStore>
+      | ((state: LabelStore) => LabelStore | Partial<LabelStore>),
+  ) => void,
+) {
+  fetchPrinterSettings(printerId)
+    .then((saved) => {
+      if (!saved) return;
+      set((state) => {
+        const patch: Partial<LabelSettings> = {};
+        for (const key of [
+          "tapeSizeMm",
+          "foregroundColor",
+          "backgroundColor",
+        ] as const) {
+          if (saved[key] !== undefined) {
+            (patch as Record<string, unknown>)[key] = saved[key];
+          }
+        }
+        if (Object.keys(patch).length === 0) return state;
+        return { settings: { ...state.settings, ...patch } };
+      });
+    })
+    .catch((err) => {
+      console.warn("Failed to load printer settings:", err);
+    });
+}

--- a/server/app.py
+++ b/server/app.py
@@ -22,6 +22,7 @@ import power_save
 import usb_power
 from label_builder import paint_cut_mark_in_trailing_margin, preview_label, render_payload
 from printer_service import list_printers, print_bitmap, print_label
+import printer_settings
 
 # Seconds to wait after power-on before reading status, so the device has
 # time to re-enumerate on the USB bus.
@@ -180,6 +181,34 @@ def api_serve_upload(filename):
 @app.route("/api/printers", methods=["GET"])
 def api_printers():
     return jsonify(printers=list_printers())
+
+
+@app.route("/api/printers/<printer_id>/settings", methods=["GET"])
+def api_get_printer_settings(printer_id: str):
+    """Return persisted label settings for a specific printer.
+
+    Returns ``null`` when no settings have been saved for this printer
+    — the client treats that as "use defaults".
+    """
+    stored = printer_settings.get_settings(printer_id)
+    if stored is not None:
+        return jsonify(stored)
+    return jsonify(None)
+
+
+@app.route("/api/printers/<printer_id>/settings", methods=["PUT"])
+def api_put_printer_settings(printer_id: str):
+    """Save label settings for a specific printer.
+
+    Accepts a JSON object with any subset of the persistable fields
+    (tapeSizeMm, foregroundColor, backgroundColor). Unknown fields
+    are silently ignored.
+    """
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return jsonify(status="error", message="Request body must be a JSON object"), 400
+    printer_settings.save_settings(printer_id, data)
+    return jsonify(status="ok")
 
 
 def _printer_port_or_404():

--- a/server/printer_settings.py
+++ b/server/printer_settings.py
@@ -1,0 +1,94 @@
+"""Per-printer label settings persistence.
+
+Stores per-printer label settings (tape size, foreground/background
+color) in the same LABELLE_STATE_FILE used by usb_power, under a
+``printer_settings`` key. Matches the existing atomic-write + tolerant-
+read patterns so the two modules coexist in one file without clobbering
+each other.
+
+A write failure (read-only fs, missing volume mount, permissions) is
+logged and ignored — runtime never breaks just because state can't be
+persisted.
+"""
+
+import json
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+STATE_FILE = Path(
+    os.environ.get("LABELLE_STATE_FILE", "/app/output/.labelle/state.json")
+)
+
+SETTINGS_KEY = "printer_settings"
+
+# Fields from LabelSettings we persist per-printer. These are the
+# "physical printer property" fields listed in the issue.  marginPx,
+# minLengthMm, justify, and cutMark are deliberately excluded — they're
+# label preferences, not printer properties.
+PERSISTED_FIELDS = frozenset({"tapeSizeMm", "foregroundColor", "backgroundColor"})
+
+
+def _read_full_state() -> dict:
+    """Read the full state dict from disk, or empty dict if absent/invalid."""
+    try:
+        data = json.loads(STATE_FILE.read_text())
+        if isinstance(data, dict):
+            return data
+    except FileNotFoundError:
+        return {}
+    except (OSError, json.JSONDecodeError) as e:
+        logger.warning("Could not read state from %s: %s", STATE_FILE, e)
+    return {}
+
+
+def _write_full_state(state: dict) -> None:
+    """Atomically write the full state dict to disk."""
+    try:
+        STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        tmp = STATE_FILE.with_suffix(STATE_FILE.suffix + ".tmp")
+        tmp.write_text(json.dumps(state))
+        tmp.replace(STATE_FILE)
+    except OSError as e:
+        logger.warning("Could not write state to %s: %s", STATE_FILE, e)
+
+
+def get_settings(printer_id: str) -> dict | None:
+    """Return persisted settings for a printer, or None if none saved."""
+    state = _read_full_state()
+    settings_map = state.get(SETTINGS_KEY, {})
+    if not isinstance(settings_map, dict):
+        return None
+    stored = settings_map.get(printer_id)
+    if isinstance(stored, dict):
+        return stored
+    return None
+
+
+def save_settings(printer_id: str, settings: dict) -> None:
+    """Persist per-printer settings, merging into existing state.
+
+    Only fields in ``PERSISTED_FIELDS`` are stored — everything else is
+    silently dropped.
+    """
+    state = _read_full_state()
+    settings_map = state.get(SETTINGS_KEY)
+    if not isinstance(settings_map, dict):
+        settings_map = {}
+        state[SETTINGS_KEY] = settings_map
+
+    filtered: dict[str, object] = {}
+    for k, v in settings.items():
+        if k in PERSISTED_FIELDS:
+            filtered[k] = v
+
+    # Don't store an empty dict — remove the key so the state file
+    # stays clean when a user resets settings to all defaults.
+    if filtered:
+        settings_map[printer_id] = filtered
+    else:
+        settings_map.pop(printer_id, None)
+
+    _write_full_state(state)

--- a/server/tests/test_printer_settings.py
+++ b/server/tests/test_printer_settings.py
@@ -1,0 +1,137 @@
+"""Tests for printer_settings — per-printer label settings persistence."""
+
+import json
+
+import printer_settings
+
+
+class TestGetSettings:
+    def test_returns_none_when_file_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(printer_settings, "STATE_FILE", tmp_path / "absent.json")
+        assert printer_settings.get_settings("printer-1") is None
+
+    def test_returns_none_when_printer_not_in_file(self, tmp_path, monkeypatch):
+        p = tmp_path / "state.json"
+        p.write_text(json.dumps({"printer_settings": {"other": {"tapeSizeMm": 12}}}))
+        monkeypatch.setattr(printer_settings, "STATE_FILE", p)
+        assert printer_settings.get_settings("printer-1") is None
+
+    def test_returns_stored_settings(self, tmp_path, monkeypatch):
+        p = tmp_path / "state.json"
+        p.write_text(json.dumps({
+            "printer_settings": {
+                "Bus 001: ID 0922:1002": {
+                    "tapeSizeMm": 19,
+                    "foregroundColor": "red",
+                    "backgroundColor": "yellow",
+                }
+            }
+        }))
+        monkeypatch.setattr(printer_settings, "STATE_FILE", p)
+        result = printer_settings.get_settings("Bus 001: ID 0922:1002")
+        assert result == {
+            "tapeSizeMm": 19,
+            "foregroundColor": "red",
+            "backgroundColor": "yellow",
+        }
+
+    def test_handles_corrupt_json(self, tmp_path, monkeypatch):
+        p = tmp_path / "state.json"
+        p.write_text("{not json")
+        monkeypatch.setattr(printer_settings, "STATE_FILE", p)
+        assert printer_settings.get_settings("printer-1") is None
+
+    def test_handles_non_dict_state(self, tmp_path, monkeypatch):
+        p = tmp_path / "state.json"
+        p.write_text("[]")
+        monkeypatch.setattr(printer_settings, "STATE_FILE", p)
+        assert printer_settings.get_settings("printer-1") is None
+
+
+class TestSaveSettings:
+    def test_saves_and_round_trips(self, tmp_path, monkeypatch):
+        p = tmp_path / "state.json"
+        monkeypatch.setattr(printer_settings, "STATE_FILE", p)
+
+        printer_settings.save_settings("printer-A", {
+            "tapeSizeMm": 12,
+            "foregroundColor": "black",
+            "backgroundColor": "white",
+        })
+
+        result = printer_settings.get_settings("printer-A")
+        assert result == {
+            "tapeSizeMm": 12,
+            "foregroundColor": "black",
+            "backgroundColor": "white",
+        }
+
+    def test_filters_unknown_fields(self, tmp_path, monkeypatch):
+        p = tmp_path / "state.json"
+        monkeypatch.setattr(printer_settings, "STATE_FILE", p)
+
+        printer_settings.save_settings("printer-A", {
+            "tapeSizeMm": 12,
+            "marginPx": 99,       # not persisted
+            "justify": "left",    # not persisted
+            "unknownField": True,
+        })
+
+        result = printer_settings.get_settings("printer-A")
+        assert "tapeSizeMm" in result
+        assert "marginPx" not in result
+        assert "justify" not in result
+        assert "unknownField" not in result
+
+    def test_does_not_clobber_usb_power_data(self, tmp_path, monkeypatch):
+        """Saving printer settings must not destroy hub/port data stored by usb_power."""
+        p = tmp_path / "state.json"
+        p.write_text(json.dumps({"hub": "1-1", "port": 3}))
+        monkeypatch.setattr(printer_settings, "STATE_FILE", p)
+
+        printer_settings.save_settings("printer-A", {"tapeSizeMm": 12})
+
+        data = json.loads(p.read_text())
+        assert data["hub"] == "1-1"
+        assert data["port"] == 3
+        assert "printer_settings" in data
+
+    def test_multiple_printers(self, tmp_path, monkeypatch):
+        p = tmp_path / "state.json"
+        monkeypatch.setattr(printer_settings, "STATE_FILE", p)
+
+        printer_settings.save_settings("printer-A", {"tapeSizeMm": 6})
+        printer_settings.save_settings("printer-B", {"tapeSizeMm": 19})
+        printer_settings.save_settings("virtual:Office", {
+            "tapeSizeMm": 12,
+            "foregroundColor": "blue",
+        })
+
+        assert printer_settings.get_settings("printer-A") == {"tapeSizeMm": 6}
+        assert printer_settings.get_settings("printer-B") == {"tapeSizeMm": 19}
+        assert printer_settings.get_settings("virtual:Office") == {
+            "tapeSizeMm": 12,
+            "foregroundColor": "blue",
+        }
+
+    def test_removes_entry_when_all_fields_empty(self, tmp_path, monkeypatch):
+        """Saving an empty or invalid dict should remove the printer's settings entry."""
+        p = tmp_path / "state.json"
+        monkeypatch.setattr(printer_settings, "STATE_FILE", p)
+
+        printer_settings.save_settings("printer-A", {"tapeSizeMm": 12})
+        assert printer_settings.get_settings("printer-A") is not None
+
+        # Save with no valid persisted fields
+        printer_settings.save_settings("printer-A", {"marginPx": 99})
+        assert printer_settings.get_settings("printer-A") is None
+
+    def test_swallows_write_errors(self, tmp_path, monkeypatch):
+        """save_settings must never raise, even if the filesystem is broken."""
+        blocker = tmp_path / "blocker"
+        blocker.write_text("not a dir")
+        bad_path = blocker / "state.json"
+        monkeypatch.setattr(printer_settings, "STATE_FILE", bad_path)
+
+        # Should not raise
+        printer_settings.save_settings("printer-A", {"tapeSizeMm": 12})

--- a/server/usb_power.py
+++ b/server/usb_power.py
@@ -134,17 +134,24 @@ _STATE_FILE = Path(
 )
 
 
-def _load_state(path: Path | None = None) -> tuple[str, int] | None:
-    """Read a previously-saved (hub, port) from disk, or None if absent/invalid."""
+def _read_full_state(path: Path | None = None) -> dict:
+    """Read the full state dict from disk, or empty dict if absent/invalid."""
     if path is None:
         path = _STATE_FILE
     try:
         data = json.loads(path.read_text())
+        if isinstance(data, dict):
+            return data
     except FileNotFoundError:
-        return None
+        return {}
     except (OSError, json.JSONDecodeError) as e:
-        logger.warning("Could not load printer port state from %s: %s", path, e)
-        return None
+        logger.warning("Could not load state from %s: %s", path, e)
+    return {}
+
+
+def _load_state(path: Path | None = None) -> tuple[str, int] | None:
+    """Read a previously-saved (hub, port) from disk, or None if absent/invalid."""
+    data = _read_full_state(path)
     hub = data.get("hub")
     port = data.get("port")
     if isinstance(hub, str) and isinstance(port, int):
@@ -157,6 +164,9 @@ def _load_state(path: Path | None = None) -> tuple[str, int] | None:
 
 def _save_state(hub: str, port: int, path: Path | None = None) -> None:
     """Persist (hub, port) so a container restart can recover the cache.
+
+    Merges into the existing state dict so other modules that store data
+    in the same file (e.g. per-printer label settings) aren't clobbered.
 
     Best-effort: a write failure (read-only fs, missing volume mount,
     permissions) only loses cross-restart memory, never breaks runtime.
@@ -171,8 +181,11 @@ def _save_state(hub: str, port: int, path: Path | None = None) -> None:
         path = _STATE_FILE
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
+        state = _read_full_state(path)
+        state["hub"] = hub
+        state["port"] = port
         tmp = path.with_suffix(path.suffix + ".tmp")
-        tmp.write_text(json.dumps({"hub": hub, "port": port}))
+        tmp.write_text(json.dumps(state))
         tmp.replace(path)
     except OSError as e:
         logger.warning("Could not save printer port state to %s: %s", path, e)


### PR DESCRIPTION
## Summary

Saves per-printer label settings (tape size, foreground color, background color) so users don't have to re-select them on every visit. When a user selects a printer from the dropdown, its last-used tape/color configuration is restored automatically. Changing tape size or colors while a printer is selected persists the new values immediately.

Closes #20.

## What changes

### Server-side
- **New** `server/printer_settings.py` — per-printer settings CRUD using the existing `LABELLE_STATE_FILE` with the same atomic read-merge-write pattern as `usb_power.py`
- **Modified** `server/usb_power.py` — `_save_state` now merges with existing state dict instead of overwriting, so `printer_settings` and `hub`/`port` keys coexist safely
- **New endpoints** in `server/app.py`:
  - `GET /api/printers/<id>/settings` — returns `null` or saved settings
  - `PUT /api/printers/<id>/settings` — persists settings (only `tapeSizeMm`, `foregroundColor`, `backgroundColor` are stored)
- **New tests** `server/tests/test_printer_settings.py` — 11 tests covering read/write, multiple printers, corrupt JSON, non-clobber of USB data, write error swallowing

### Client-side
- **Modified** `client/src/lib/api.ts` — added `fetchPrinterSettings()` and `savePrinterSettings()` with URL-encoded printer IDs
- **Updated** `client/src/state/useLabelStore.ts`:
  - `updateSettings` now loads saved settings when `printerId` changes
  - `updateSettings` auto-saves tape/color changes for the current printer
  - `setAvailablePrinters` triggers a load when printers arrive after mount

### Design decisions
- Only 3 fields persisted: `tapeSizeMm`, `foregroundColor`, `backgroundColor` — these are physical printer properties. `marginPx`, `minLengthMm`, `justify`, and `cutMark` are label preferences and not tied to a specific printer.
- Settings keyed by `PrinterInfo.id` (USB ID or `virtual:name`) — stable across reboots.
- Empty settings dict → entry removed from state file, keeping it clean.

## Testing
- All 71 server tests pass (25 usb_power + 11 printer_settings + 35 app)
- Tested: round-trip save/load, multiple printers, corrupt JSON resilience, non-clobber of hub/port data, write-error swallowing, unknown field filtering