### PR TITLE
feat: runtime version display + drop `-dev` suffix from package.json

### DIFF
--- a/.github/release-notes/v1.6.2.md
+++ b/.github/release-notes/v1.6.2.md
@@ -8,7 +8,7 @@ The footer at the bottom of the page now reads its version, commit, and branch f
 
 ### Developer-facing: no more `-dev` suffix in package.json
 
-Previously, working on a feature branch meant flipping `1.6.X-dev` ↔ `1.6.X` in `package.json` by hand at merge time. That's gone. `package.json` now always holds the version this commit *would* release if merged, and the `-dev` marker is added at display time based on `branch !== "main"` from `/api/health`. One less merge-time chore.
+Previously, working on a feature branch meant flipping `1.6.X-dev` ↔ `1.6.X` in `package.json` by hand at merge time. That's gone. `package.json` now always holds the version this commit *would* release if merged, and the `-dev` marker is added at display time when `/api/health` reports a `branch` that isn't `main` (if the health call fails, the footer omits `-dev` rather than mislabeling a build with no commit info). One less merge-time chore.
 
 `docs/ARCHITECTURE.md` has a new short "Versioning convention" subsection that describes the new flow.
 

--- a/.github/release-notes/v1.6.2.md
+++ b/.github/release-notes/v1.6.2.md
@@ -1,0 +1,15 @@
+## Footer shows real build info
+
+The footer at the bottom of the page now reads its version, commit, and branch from the *running* server's `/api/health` instead of from a Vite build-time constant. Practical effect:
+
+- **Production builds** (released from `main`) show a clean `v1.6.2` as before.
+- **Dev / PR / local builds** show `v1.6.2-dev (abc1234)` so you can tell at a glance whether you're looking at a release or a preview.
+- The "newer release available" prompt only fires on production builds — previously it could falsely flag feature-branch builds as out-of-date even when they were ahead.
+
+### Developer-facing: no more `-dev` suffix in package.json
+
+Previously, working on a feature branch meant flipping `1.6.X-dev` ↔ `1.6.X` in `package.json` by hand at merge time. That's gone. `package.json` now always holds the version this commit *would* release if merged, and the `-dev` marker is added at display time based on `branch !== "main"` from `/api/health`. One less merge-time chore.
+
+`docs/ARCHITECTURE.md` has a new short "Versioning convention" subsection that describes the new flow.
+
+---

--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -2,28 +2,63 @@ import { useEffect, useState } from "react";
 
 const REPO_URL = "https://github.com/szrudi/labelle-web";
 
+interface HealthInfo {
+  version: string;
+  commit?: string;
+  branch?: string;
+}
+
 export function Footer() {
+  const [health, setHealth] = useState<HealthInfo | null>(null);
   const [latestVersion, setLatestVersion] = useState<string | null>(null);
 
+  // Read the running server's `/api/health` for the real version, branch
+  // and commit. The Vite-injected __APP_VERSION__ is a build-time
+  // fallback for the very early window before the API responds.
   useEffect(() => {
+    fetch("/api/health")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: HealthInfo | null) => {
+        if (data?.version) setHealth(data);
+      })
+      .catch(() => {});
+  }, []);
+
+  // Only nag about a newer release when we're on a production build —
+  // dev builds are usually ahead of the latest tag, and `latest !==
+  // version` would otherwise flag every feature branch as "out of date".
+  const onMain = health?.branch === "main";
+  useEffect(() => {
+    if (!health?.version || !onMain) return;
     fetch("https://api.github.com/repos/szrudi/labelle-web/releases/latest")
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => {
         if (!data?.tag_name) return;
         const latest = data.tag_name.replace(/^v/, "");
-        if (latest !== __APP_VERSION__) {
+        if (latest !== health.version) {
           setLatestVersion(latest);
         }
       })
       .catch(() => {});
-  }, []);
+  }, [health?.version, onMain]);
+
+  const version = health?.version ?? __APP_VERSION__;
+  const commit = health?.commit;
+  // "Dev" = anything not built from main. release.yml stamps GIT_BRANCH=main
+  // for production images, so onMain is a reliable signal.
+  const isDev = health?.branch !== undefined && !onMain;
 
   return (
     <footer className="mt-8 text-center text-xs text-gray-400">
       <a href={REPO_URL} target="_blank" rel="noopener noreferrer" className="hover:text-gray-600">
         Labelle Web
       </a>{" "}
-      v{__APP_VERSION__}
+      v{version}
+      {isDev && (
+        <span className="text-gray-500">
+          -dev{commit && ` (${commit})`}
+        </span>
+      )}
       {latestVersion && (
         <>
           {" · "}

--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -16,12 +16,16 @@ export function Footer() {
   // and commit. The Vite-injected __APP_VERSION__ is a build-time
   // fallback for the very early window before the API responds.
   useEffect(() => {
-    fetch("/api/health")
+    const controller = new AbortController();
+    fetch("/api/health", { signal: controller.signal })
       .then((res) => (res.ok ? res.json() : null))
       .then((data: HealthInfo | null) => {
         if (data?.version) setHealth(data);
       })
-      .catch(() => {});
+      .catch(() => {
+        // AbortError on unmount, or network failure — fall back to __APP_VERSION__.
+      });
+    return () => controller.abort();
   }, []);
 
   // Only nag about a newer release when we're on a production build —
@@ -30,7 +34,10 @@ export function Footer() {
   const onMain = health?.branch === "main";
   useEffect(() => {
     if (!health?.version || !onMain) return;
-    fetch("https://api.github.com/repos/szrudi/labelle-web/releases/latest")
+    const controller = new AbortController();
+    fetch("https://api.github.com/repos/szrudi/labelle-web/releases/latest", {
+      signal: controller.signal,
+    })
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => {
         if (!data?.tag_name) return;
@@ -39,7 +46,10 @@ export function Footer() {
           setLatestVersion(latest);
         }
       })
-      .catch(() => {});
+      .catch(() => {
+        // AbortError on unmount, or GH API unreachable — skip the "newer release" hint.
+      });
+    return () => controller.abort();
   }, [health?.version, onMain]);
 
   const version = health?.version ?? __APP_VERSION__;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -203,7 +203,7 @@ GET /api/health
 
 ### Versioning convention
 
-`package.json` always holds the version this commit *would* release if merged — there is **no `-dev` suffix on feature branches**. The footer (`client/src/components/Footer.tsx`) reads `/api/health` at runtime and renders `v{version}-dev ({commit})` whenever `branch !== "main"`, so dev / PR / local builds are visually distinguishable from production releases without needing to mutate `package.json` at merge time. `release.yml` tags `vX.Y.Z` when the version on `main` changes, so the merge commit *is* the release commit.
+`package.json` always holds the version this commit *would* release if merged — there is **no `-dev` suffix on feature branches**. The footer (`client/src/components/Footer.tsx`) reads `/api/health` at runtime and renders `v{version}-dev ({commit})` whenever `/api/health` reports a `branch` that isn't `main` (if the health call fails the footer omits `-dev` rather than mislabeling a build with no commit info). Dev / PR / local builds are therefore visually distinguishable from production releases without needing to mutate `package.json` at merge time. `release.yml` tags `vX.Y.Z` when the version on `main` changes, so the merge commit *is* the release commit.
 
 ### Label Builder (`label_builder.py`)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -196,8 +196,14 @@ POST /api/batch-print/cancel
 GET /api/health
   -> app.py (api_health)
     -> Read version from package.json
-  <- { status, version }
+    -> Read commit + branch from GIT_SHA/GIT_BRANCH env (set at Docker build)
+       or git rev-parse fallback
+  <- { status, version, commit, branch }
 ```
+
+### Versioning convention
+
+`package.json` always holds the version this commit *would* release if merged — there is **no `-dev` suffix on feature branches**. The footer (`client/src/components/Footer.tsx`) reads `/api/health` at runtime and renders `v{version}-dev ({commit})` whenever `branch !== "main"`, so dev / PR / local builds are visually distinguishable from production releases without needing to mutate `package.json` at merge time. `release.yml` tags `vX.Y.Z` when the version on `main` changes, so the merge commit *is* the release commit.
 
 ### Label Builder (`label_builder.py`)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labelle-web",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "private": true,
   "description": "Web interface for labelle DYMO label printers",
   "scripts": {


### PR DESCRIPTION
## Summary

Two related cleanups around the version string:

1. **Footer reads `/api/health` at runtime** instead of using the Vite build-time `__APP_VERSION__`. Shows `v1.6.2` on production builds, `v1.6.2-dev (abc1234)` on dev / PR / local builds.
2. **Drops the `-dev` suffix in `package.json`** on feature branches. The suffix is now purely a display-time concern; `package.json` always holds the version this commit would release if merged.

## Why

- The `-dev` ↔ clean flip at merge time was hand-managed and easy to forget. The merge commit was the release commit, but the version-string flip was a separate step that often slipped.
- The footer already had `{version, commit, branch}` available via `/api/health` — it just wasn't using them. Production vs dev was indistinguishable at a glance.
- Side benefit: the "newer release available" nag in the footer now only fires when we're on `main`. Previously a feature branch at `1.6.3` would falsely flag `v1.6.2` as a "newer" available release.

## What changes

- `client/src/components/Footer.tsx` — fetches `/api/health`, shows `-dev (commit)` suffix when `branch !== "main"`, gates the "newer release" check on `onMain`. Falls back to `__APP_VERSION__` when `/api/health` is unreachable.
- `docs/ARCHITECTURE.md` — new short "Versioning convention" subsection. Also expands the `/api/health` response shape to mention `commit` and `branch`.
- `package.json` — bumped to `1.6.2`. From this PR onward, no `-dev` suffix on feature branches.

## Version

`1.6.2` (PATCH). UX improvement, no behavioural change.

## Test plan

- [x] Client: 52 vitest tests pass (no new tests — Footer isn't currently under test and adding one for an effect-driven fetch isn't proportional to the scope)
- [x] Client build green
- [x] Manually: tested in dev (`npm run dev`) where `branch` comes back as a feature-branch name — footer shows `-dev (sha)` as expected
- [ ] Hardware: not required, no print-path change

## Merge order

Merge this **before** #25 so the variable-syntax PR lands as the latest release (1.6.3).