### PR TITLE
fix(batch): auto-select row 0 when batch mode first activates

### DIFF
--- a/.github/release-notes/v1.6.4.md
+++ b/.github/release-notes/v1.6.4.md
@@ -1,0 +1,7 @@
+## Batch mode now auto-previews row 1
+
+When batch mode first activates — either by clicking "+ Add Variable" or by typing `{{name}}` directly into a widget — the first row's preview is now active by default. Typing values into row 1 updates the live preview immediately, with no need to click the eye icon first.
+
+Existing flows are untouched: clicking the eye icon to deselect still works, and loading a label file with a pre-selected row still respects whatever selection the file contained.
+
+---

--- a/client/src/components/BatchPanel.test.tsx
+++ b/client/src/components/BatchPanel.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { BatchPanel } from "./BatchPanel";
+import { useLabelStore } from "../state/useLabelStore";
+import { DEFAULT_FONT_SCALE, DEFAULT_MARGIN_PX } from "../lib/constants";
+
+afterEach(() => {
+  cleanup();
+});
+
+beforeEach(() => {
+  useLabelStore.setState({
+    widgets: [
+      {
+        id: "w1",
+        type: "text",
+        text: "",
+        fontStyle: "regular",
+        fontScale: DEFAULT_FONT_SCALE,
+        frameWidthPx: 0,
+        align: "left",
+      },
+    ],
+    settings: {
+      tapeSizeMm: 12,
+      marginPx: DEFAULT_MARGIN_PX,
+      minLengthMm: 0,
+      justify: "center",
+      foregroundColor: "black",
+      backgroundColor: "white",
+      showMargins: false,
+      cutMark: false,
+    },
+    batch: {
+      copies: 1,
+      pauseTime: 0,
+      rows: [{ id: "r0", values: {} }],
+      selectedRowIndex: null,
+    },
+  });
+});
+
+describe("BatchPanel auto-selects row 0 when batch mode first activates", () => {
+  it("auto-selects row 0 after clicking + Add Variable", async () => {
+    render(<BatchPanel />);
+
+    expect(useLabelStore.getState().batch.selectedRowIndex).toBeNull();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /Add Variable/i }),
+    );
+
+    expect(useLabelStore.getState().batch.selectedRowIndex).toBe(0);
+  });
+
+  it("does not re-select row 0 after the user deselects via the eye icon", async () => {
+    render(<BatchPanel />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /Add Variable/i }),
+    );
+    expect(useLabelStore.getState().batch.selectedRowIndex).toBe(0);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /Stop previewing row 1/i }),
+    );
+
+    expect(useLabelStore.getState().batch.selectedRowIndex).toBeNull();
+  });
+});

--- a/client/src/components/BatchPanel.tsx
+++ b/client/src/components/BatchPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useLabelStore } from "../state/useLabelStore";
 import { detectVariables } from "../lib/variables";
 import {
@@ -48,6 +48,27 @@ export function BatchPanel() {
   useEffect(() => {
     if (hasVariables) setOpen(true);
   }, [hasVariables]);
+
+  // Auto-select row 0 on the false->true transition of hasVariables so the
+  // preview substitutes immediately when batch mode first activates (button
+  // click or typing {{...}} into a widget). The transition check is
+  // load-bearing: a plain "select if null" effect would fight the user every
+  // time they deselect via the eye icon (which sets selectedRowIndex back to
+  // null). On initial mount the ref captures the starting value, so a loaded
+  // file's selectedRowIndex is preserved.
+  const prevHasVariablesRef = useRef(hasVariables);
+  useEffect(() => {
+    const prev = prevHasVariablesRef.current;
+    prevHasVariablesRef.current = hasVariables;
+    if (
+      !prev &&
+      hasVariables &&
+      batch.selectedRowIndex === null &&
+      batch.rows.length > 0
+    ) {
+      updateBatch({ selectedRowIndex: 0 });
+    }
+  }, [hasVariables, batch.selectedRowIndex, batch.rows.length, updateBatch]);
 
   // Local string state for number inputs so the user can clear and retype
   // without the value snapping back to a clamped minimum mid-edit.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labelle-web",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "private": true,
   "description": "Web interface for labelle DYMO label printers",
   "scripts": {


### PR DESCRIPTION
## Summary
- Auto-selects the first batch row on the false→true transition of `hasVariables`, so the live preview substitutes immediately when batch mode first activates (clicking "+ Add Variable" or typing `{{name}}` into a widget).
- Transition check is load-bearing: a plain "select if null" effect would fight the user every time they deselect via the eye icon. On initial mount the ref captures the starting value, so a loaded file's saved `selectedRowIndex` is preserved.
- Adds a `BatchPanel.test.tsx` covering the activate case and the deselect case.
- Bumps to 1.6.4 (PATCH — bug fix, no new behavior).

## Test plan
- [x] `npm test` — new `BatchPanel` tests pass
- [ ] Click "+ Add Variable" with an empty widget → row 1 is previewed
- [ ] Type `{{name}}` into a widget → row 1 is previewed
- [ ] Click the eye icon to deselect → preview clears and stays cleared while typing
- [ ] Load a label file with `selectedRowIndex` set → that selection is respected on load

🤖 Generated with [Claude Code](https://claude.com/claude-code)