### PR TITLE
ci(pr-image): sweep predecessor image on each push

### DIFF
--- a/.github/scripts/sweep-ghcr-versions.sh
+++ b/.github/scripts/sweep-ghcr-versions.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Delete GHCR container package versions AND the per-arch image
+# and provenance attestation manifests they reference.
+#
+# GHCR does not cascade-delete manifest-list children, so a naive
+# parent-only delete leaks ~4 untagged versions per multi-arch build
+# (2 per-arch image manifests + 2 attestation manifests). This script
+# walks each parent's manifest via the registry API and deletes the
+# referenced child versions alongside the parent.
+#
+# Input:  parent version IDs on stdin, one per line.
+# Env:    GH_TOKEN, OWNER, PACKAGE, IMAGE_NAME, GITHUB_ACTOR, SNAPSHOT
+#         SNAPSHOT is a path to a JSON file shaped as
+#         `[{id, name, tags}, ...]`, the output of the GHCR versions
+#         API massaged into a stable form. Callers must produce it
+#         AFTER any push that affects the same package, so digests
+#         and IDs of any newly-pushed image are present and not
+#         mistakenly enumerated as orphans.
+
+set -euo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+: "${OWNER:?OWNER is required}"
+: "${PACKAGE:?PACKAGE is required}"
+: "${IMAGE_NAME:?IMAGE_NAME is required (e.g. owner/repo)}"
+: "${GITHUB_ACTOR:?GITHUB_ACTOR is required}"
+: "${SNAPSHOT:?SNAPSHOT path is required}"
+
+# Pull-scope registry token, distinct from GH_TOKEN. The GitHub token
+# is accepted as the password against the actor on GHCR's token
+# endpoint, which returns a registry-scoped bearer.
+REG_TOKEN=$(curl -fsSL -u "$GITHUB_ACTOR:$GH_TOKEN" \
+  "https://ghcr.io/token?scope=repository:$IMAGE_NAME:pull&service=ghcr.io" \
+  | jq -r .token)
+
+TO_DELETE=$(mktemp)
+CURL_ERR=$(mktemp)
+trap 'rm -f "$TO_DELETE" "$CURL_ERR"' EXIT
+
+while IFS= read -r PARENT_ID; do
+  [ -z "$PARENT_ID" ] && continue
+  echo "$PARENT_ID" >> "$TO_DELETE"
+
+  DIGEST=$(jq -r --argjson id "$PARENT_ID" \
+    '.[] | select(.id == $id) | .name' "$SNAPSHOT")
+  if [ -z "$DIGEST" ] || [ "$DIGEST" = "null" ]; then
+    echo "::warning::No digest in snapshot for version $PARENT_ID — children may leak"
+    continue
+  fi
+
+  if MANIFEST=$(curl -fsSL \
+      -H "Authorization: Bearer $REG_TOKEN" \
+      -H "Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json" \
+      "https://ghcr.io/v2/$IMAGE_NAME/manifests/$DIGEST" 2>"$CURL_ERR"); then
+    # Single-arch manifests have no `.manifests` array; `?` makes this a no-op.
+    echo "$MANIFEST" | jq -r '.manifests[]?.digest // empty' \
+      | while IFS= read -r CHILD_DIGEST; do
+          [ -z "$CHILD_DIGEST" ] && continue
+          CHILD_ID=$(jq -r --arg d "$CHILD_DIGEST" \
+            '.[] | select(.name == $d) | .id' "$SNAPSHOT")
+          if [ -n "$CHILD_ID" ] && [ "$CHILD_ID" != "null" ]; then
+            echo "$CHILD_ID" >> "$TO_DELETE"
+          else
+            echo "::warning::Child digest $CHILD_DIGEST not in snapshot — skipping"
+          fi
+        done
+  elif grep -q "404" "$CURL_ERR"; then
+    echo "::warning::Manifest $DIGEST already gone from registry — parent only"
+  else
+    echo "::error::Failed to fetch manifest $DIGEST:"
+    cat "$CURL_ERR" >&2
+    exit 1
+  fi
+done
+
+if ! [ -s "$TO_DELETE" ]; then
+  echo "No versions to delete"
+  exit 0
+fi
+sort -u "$TO_DELETE" | while IFS= read -r VID; do
+  [ -z "$VID" ] && continue
+  echo "Deleting version $VID"
+  gh api -X DELETE "/users/$OWNER/packages/container/$PACKAGE/versions/$VID"
+done

--- a/.github/workflows/pr-image.yml
+++ b/.github/workflows/pr-image.yml
@@ -79,9 +79,10 @@ jobs:
         run: echo "short=${HEAD_SHA:0:7}" >> "$GITHUB_OUTPUT"
 
       # Capture the version IDs currently tagged `:pr-<N>` *before*
-      # we push. After the push the tag moves to the new version, so
-      # these IDs are the predecessor(s) to delete. Normally there's
-      # exactly one; we handle a list in case a prior run left dupes.
+      # we push. These are candidate predecessors; the actual delete
+      # set is `pre - post` (see the post-push step), so a re-run on
+      # the same commit (manifest digest unchanged → tag stays on the
+      # same version ID) does not delete the only image for this PR.
       - name: Find predecessor PR image versions
         id: predecessors
         env:
@@ -90,13 +91,29 @@ jobs:
           OWNER: ${{ github.repository_owner }}
           PACKAGE: ${{ github.event.repository.name }}
         run: |
-          set -eu
-          VERSIONS=$(gh api \
+          set -euo pipefail
+          # The only expected failure here is HTTP 404 on the very
+          # first build of a brand-new PR (package doesn't exist yet).
+          # Other failures (auth/perms/rate-limit) must NOT degrade
+          # silently into "no cleanup" — they fail the job.
+          ERR=$(mktemp)
+          trap 'rm -f "$ERR"' EXIT
+          if IDS=$(gh api \
             "/users/$OWNER/packages/container/$PACKAGE/versions" --paginate \
-            --jq ".[] | select(.metadata.container.tags | index(\"$PR_TAG\")) | .id" || true)
+            --jq ".[] | select(((.metadata.container.tags // []) | index(\"$PR_TAG\"))) | .id" \
+            2>"$ERR"); then
+            :
+          elif grep -q "HTTP 404" "$ERR"; then
+            echo "Package not found yet — first build for this PR."
+            IDS=""
+          else
+            echo "::error::Listing package versions failed:"
+            cat "$ERR" >&2
+            exit 1
+          fi
           {
             echo "ids<<EOF"
-            echo "$VERSIONS"
+            echo "$IDS"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
@@ -123,23 +140,41 @@ jobs:
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
 
-      # Delete the predecessor versions we captured pre-build. Runs
-      # only after a successful push, so a failed build leaves the
-      # existing `:pr-<N>` image in place.
-      - name: Delete predecessor PR image versions
+      # Delete only versions that were tagged `:pr-<N>` pre-build AND
+      # are no longer tagged post-push. Re-querying post-push avoids a
+      # bug where a workflow re-run on the same commit (or any push
+      # that produces an identical manifest digest) would otherwise
+      # delete the version that still carries the `:pr-<N>` tag — i.e.
+      # the only image for this PR.
+      - name: Delete superseded PR image versions
         if: steps.predecessors.outputs.ids != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_TAG: pr-${{ github.event.pull_request.number }}
           OWNER: ${{ github.repository_owner }}
           PACKAGE: ${{ github.event.repository.name }}
-          VERSION_IDS: ${{ steps.predecessors.outputs.ids }}
+          PRE_IDS: ${{ steps.predecessors.outputs.ids }}
         run: |
-          set -eu
+          set -euo pipefail
+          CURRENT_IDS=$(gh api \
+            "/users/$OWNER/packages/container/$PACKAGE/versions" --paginate \
+            --jq ".[] | select(((.metadata.container.tags // []) | index(\"$PR_TAG\"))) | .id")
+          echo "$PRE_IDS" | grep -v '^$' | sort -u > /tmp/pre-ids.txt
+          echo "$CURRENT_IDS" | grep -v '^$' | sort -u > /tmp/current-ids.txt
+          if ! [ -s /tmp/pre-ids.txt ]; then
+            echo "No predecessor IDs to consider"
+            exit 0
+          fi
+          TO_DELETE=$(comm -23 /tmp/pre-ids.txt /tmp/current-ids.txt)
+          if [ -z "$TO_DELETE" ]; then
+            echo "No superseded versions — manifest digest unchanged across rebuild."
+            exit 0
+          fi
           while IFS= read -r VERSION_ID; do
             [ -z "$VERSION_ID" ] && continue
-            echo "Deleting predecessor version $VERSION_ID"
+            echo "Deleting superseded version $VERSION_ID"
             gh api -X DELETE "/users/$OWNER/packages/container/$PACKAGE/versions/$VERSION_ID"
-          done <<< "$VERSION_IDS"
+          done <<< "$TO_DELETE"
 
       - name: Annotate run summary
         run: |
@@ -178,10 +213,26 @@ jobs:
           OWNER: ${{ github.repository_owner }}
           PACKAGE: ${{ github.event.repository.name }}
         run: |
-          set -eu
-          VERSIONS=$(gh api \
+          set -euo pipefail
+          # Same null-safe + fail-on-non-404 pattern as the build job:
+          # if the package never existed (PR closed without a single
+          # successful build) we shrug and move on; any other error
+          # fails the job rather than silently leaving orphans.
+          ERR=$(mktemp)
+          trap 'rm -f "$ERR"' EXIT
+          if VERSIONS=$(gh api \
             "/users/$OWNER/packages/container/$PACKAGE/versions" --paginate \
-            --jq ".[] | select(.metadata.container.tags | index(\"$PR_TAG\")) | .id" || true)
+            --jq ".[] | select(((.metadata.container.tags // []) | index(\"$PR_TAG\"))) | .id" \
+            2>"$ERR"); then
+            :
+          elif grep -q "HTTP 404" "$ERR"; then
+            echo "Package not found — nothing to clean up."
+            exit 0
+          else
+            echo "::error::Listing package versions failed:"
+            cat "$ERR" >&2
+            exit 1
+          fi
           if [ -z "$VERSIONS" ]; then
             echo "No versions tagged $PR_TAG to delete"
             exit 0

--- a/.github/workflows/pr-image.yml
+++ b/.github/workflows/pr-image.yml
@@ -15,6 +15,10 @@ name: Build PR image
 # On PR close (merged or not), a cleanup job deletes the final
 # `:pr-<N>` image so it doesn't linger in GHCR forever.
 #
+# Both sweep paths also delete the per-arch image manifests and
+# provenance attestation manifests referenced by the parent — GHCR
+# does not cascade-delete them. See `.github/scripts/sweep-ghcr-versions.sh`.
+#
 # Fork PRs are skipped — their GITHUB_TOKEN is read-only and can't
 # push to GHCR or delete packages.
 
@@ -140,41 +144,42 @@ jobs:
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
 
-      # Delete only versions that were tagged `:pr-<N>` pre-build AND
-      # are no longer tagged post-push. Re-querying post-push avoids a
-      # bug where a workflow re-run on the same commit (or any push
-      # that produces an identical manifest digest) would otherwise
-      # delete the version that still carries the `:pr-<N>` tag — i.e.
-      # the only image for this PR.
-      - name: Delete superseded PR image versions
+      # Delete versions that were tagged `:pr-<N>` pre-build AND no
+      # longer hold the tag post-push, along with their per-arch and
+      # provenance child manifests (GHCR does not cascade-delete
+      # them). Re-querying post-push covers the same-digest-rebuild
+      # case where the tag stays on the same version ID — that ID is
+      # the current image and must not be touched.
+      - name: Delete superseded PR image versions (and children)
         if: steps.predecessors.outputs.ids != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_TAG: pr-${{ github.event.pull_request.number }}
           OWNER: ${{ github.repository_owner }}
           PACKAGE: ${{ github.event.repository.name }}
+          IMAGE_NAME: ${{ github.repository }}
+          GITHUB_ACTOR: ${{ github.actor }}
           PRE_IDS: ${{ steps.predecessors.outputs.ids }}
         run: |
           set -euo pipefail
-          CURRENT_IDS=$(gh api \
-            "/users/$OWNER/packages/container/$PACKAGE/versions" --paginate \
-            --jq ".[] | select(((.metadata.container.tags // []) | index(\"$PR_TAG\"))) | .id")
+          SNAPSHOT=$(mktemp --suffix=.json)
+          export SNAPSHOT
+          gh api "/users/$OWNER/packages/container/$PACKAGE/versions" --paginate \
+            --jq '[.[] | {id, name, tags: (.metadata.container.tags // [])}]' \
+            > "$SNAPSHOT"
+          jq -r --arg tag "$PR_TAG" '.[] | select(.tags | index($tag)) | .id' "$SNAPSHOT" \
+            | sort -u > /tmp/current-ids.txt
           echo "$PRE_IDS" | grep -v '^$' | sort -u > /tmp/pre-ids.txt
-          echo "$CURRENT_IDS" | grep -v '^$' | sort -u > /tmp/current-ids.txt
           if ! [ -s /tmp/pre-ids.txt ]; then
             echo "No predecessor IDs to consider"
             exit 0
           fi
-          TO_DELETE=$(comm -23 /tmp/pre-ids.txt /tmp/current-ids.txt)
-          if [ -z "$TO_DELETE" ]; then
+          PARENTS=$(comm -23 /tmp/pre-ids.txt /tmp/current-ids.txt)
+          if [ -z "$PARENTS" ]; then
             echo "No superseded versions — manifest digest unchanged across rebuild."
             exit 0
           fi
-          while IFS= read -r VERSION_ID; do
-            [ -z "$VERSION_ID" ] && continue
-            echo "Deleting superseded version $VERSION_ID"
-            gh api -X DELETE "/users/$OWNER/packages/container/$PACKAGE/versions/$VERSION_ID"
-          done <<< "$TO_DELETE"
+          echo "$PARENTS" | bash .github/scripts/sweep-ghcr-versions.sh
 
       - name: Annotate run summary
         run: |
@@ -204,27 +209,40 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       packages: write
     steps:
-      - name: Delete PR image versions
+      # Need the sweep script. Pull only the scripts dir to keep this
+      # checkout cheap on a job that otherwise touches nothing local.
+      - name: Checkout sweep script
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          sparse-checkout: .github/scripts
+
+      - name: Delete PR image versions (and children)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_TAG: pr-${{ github.event.pull_request.number }}
           OWNER: ${{ github.repository_owner }}
           PACKAGE: ${{ github.event.repository.name }}
+          IMAGE_NAME: ${{ github.repository }}
+          GITHUB_ACTOR: ${{ github.actor }}
         run: |
           set -euo pipefail
-          # Same null-safe + fail-on-non-404 pattern as the build job:
-          # if the package never existed (PR closed without a single
-          # successful build) we shrug and move on; any other error
-          # fails the job rather than silently leaving orphans.
+          # Null-safe + fail-on-non-404: a missing package (PR closed
+          # without a single successful build) is the only swallowable
+          # error; anything else fails the job rather than silently
+          # leaving orphans.
+          SNAPSHOT=$(mktemp --suffix=.json)
+          export SNAPSHOT
           ERR=$(mktemp)
           trap 'rm -f "$ERR"' EXIT
-          if VERSIONS=$(gh api \
-            "/users/$OWNER/packages/container/$PACKAGE/versions" --paginate \
-            --jq ".[] | select(((.metadata.container.tags // []) | index(\"$PR_TAG\"))) | .id" \
-            2>"$ERR"); then
-            :
+          if RAW=$(gh api \
+              "/users/$OWNER/packages/container/$PACKAGE/versions" --paginate \
+              --jq '[.[] | {id, name, tags: (.metadata.container.tags // [])}]' \
+              2>"$ERR"); then
+            echo "$RAW" > "$SNAPSHOT"
           elif grep -q "HTTP 404" "$ERR"; then
             echo "Package not found — nothing to clean up."
             exit 0
@@ -233,11 +251,9 @@ jobs:
             cat "$ERR" >&2
             exit 1
           fi
-          if [ -z "$VERSIONS" ]; then
+          PARENTS=$(jq -r --arg tag "$PR_TAG" '.[] | select(.tags | index($tag)) | .id' "$SNAPSHOT")
+          if [ -z "$PARENTS" ]; then
             echo "No versions tagged $PR_TAG to delete"
             exit 0
           fi
-          for VERSION_ID in $VERSIONS; do
-            echo "Deleting version $VERSION_ID (tag $PR_TAG)"
-            gh api -X DELETE "/users/$OWNER/packages/container/$PACKAGE/versions/$VERSION_ID"
-          done
+          echo "$PARENTS" | bash .github/scripts/sweep-ghcr-versions.sh

--- a/.github/workflows/pr-image.yml
+++ b/.github/workflows/pr-image.yml
@@ -115,11 +115,19 @@ jobs:
             cat "$ERR" >&2
             exit 1
           fi
-          {
-            echo "ids<<EOF"
-            echo "$IDS"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+          # Write a truly empty value when there are no predecessors;
+          # `echo "$IDS"` would emit a stray newline, making the step
+          # output non-empty and tripping the `if: ... != ''` gate on
+          # the delete step (which would then 404 on first builds).
+          if [ -z "$IDS" ]; then
+            echo "ids=" >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo "ids<<EOF"
+              echo "$IDS"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Extract metadata (tags, labels)
         id: meta
@@ -212,12 +220,15 @@ jobs:
       contents: read
       packages: write
     steps:
-      # Need the sweep script. Pull only the scripts dir to keep this
-      # checkout cheap on a job that otherwise touches nothing local.
+      # Need the sweep script. Use github.sha (the resolved ref that
+      # triggered this run) so the script always matches the workflow
+      # file we're executing — important for stacked PRs whose base
+      # branch may not yet contain the script. Sparse-checkout keeps
+      # this cheap on a job that otherwise touches nothing local.
       - name: Checkout sweep script
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.base.ref }}
+          ref: ${{ github.sha }}
           sparse-checkout: .github/scripts
 
       - name: Delete PR image versions (and children)

--- a/.github/workflows/pr-image.yml
+++ b/.github/workflows/pr-image.yml
@@ -6,8 +6,14 @@ name: Build PR image
 # NOT touch `:latest` or `:vX.Y.Z` — those remain owned by release.yml
 # and only update on merge to main with a version bump.
 #
-# On PR close (merged or not), a cleanup job deletes the `:pr-<N>`
-# image so it doesn't linger in GHCR forever.
+# Each push also sweeps the predecessor image for the same PR: we
+# capture whatever version currently holds the `:pr-<N>` tag before
+# building, then delete it after the new image has been pushed (the
+# tag has by then moved). This keeps GHCR holding only the latest
+# image per active PR, instead of accumulating one per commit.
+#
+# On PR close (merged or not), a cleanup job deletes the final
+# `:pr-<N>` image so it doesn't linger in GHCR forever.
 #
 # Fork PRs are skipped — their GITHUB_TOKEN is read-only and can't
 # push to GHCR or delete packages.
@@ -72,6 +78,28 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: echo "short=${HEAD_SHA:0:7}" >> "$GITHUB_OUTPUT"
 
+      # Capture the version IDs currently tagged `:pr-<N>` *before*
+      # we push. After the push the tag moves to the new version, so
+      # these IDs are the predecessor(s) to delete. Normally there's
+      # exactly one; we handle a list in case a prior run left dupes.
+      - name: Find predecessor PR image versions
+        id: predecessors
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_TAG: pr-${{ github.event.pull_request.number }}
+          OWNER: ${{ github.repository_owner }}
+          PACKAGE: ${{ github.event.repository.name }}
+        run: |
+          set -eu
+          VERSIONS=$(gh api \
+            "/users/$OWNER/packages/container/$PACKAGE/versions" --paginate \
+            --jq ".[] | select(.metadata.container.tags | index(\"$PR_TAG\")) | .id" || true)
+          {
+            echo "ids<<EOF"
+            echo "$VERSIONS"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Extract metadata (tags, labels)
         id: meta
         uses: docker/metadata-action@v5
@@ -95,6 +123,24 @@ jobs:
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
 
+      # Delete the predecessor versions we captured pre-build. Runs
+      # only after a successful push, so a failed build leaves the
+      # existing `:pr-<N>` image in place.
+      - name: Delete predecessor PR image versions
+        if: steps.predecessors.outputs.ids != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          PACKAGE: ${{ github.event.repository.name }}
+          VERSION_IDS: ${{ steps.predecessors.outputs.ids }}
+        run: |
+          set -eu
+          while IFS= read -r VERSION_ID; do
+            [ -z "$VERSION_ID" ] && continue
+            echo "Deleting predecessor version $VERSION_ID"
+            gh api -X DELETE "/users/$OWNER/packages/container/$PACKAGE/versions/$VERSION_ID"
+          done <<< "$VERSION_IDS"
+
       - name: Annotate run summary
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
@@ -113,10 +159,10 @@ jobs:
           \`\`\`
           EOF
 
-  # Delete the `:pr-<N>` image versions when the PR closes (merged or
-  # not). Old SHA-only versions left behind by superseded builds aren't
-  # explicitly cleaned here — they become untagged and can be reaped by
-  # a GHCR retention policy if needed.
+  # Delete the final `:pr-<N>` image version when the PR closes (merged
+  # or not). Predecessors are already swept by `build-and-push` on each
+  # push, so under normal conditions only one version is tagged `:pr-<N>`
+  # at close time.
   cleanup:
     if: >-
       github.event.action == 'closed' &&


### PR DESCRIPTION
## Summary
Two related fixes to `pr-image.yml`'s GHCR cleanup behavior:

**1. Stop accumulating one parent image per commit (predecessor sweep)**
Before this PR, each push tagged the new build `:pr-<N>` (which moved the tag off the previous version) and `:<short-sha>`, leaving the previous version orphaned with only the SHA tag. The on-close cleanup only deleted whatever was tagged `:pr-<N>` at close time, so the per-commit SHA-only versions accumulated indefinitely.

After: before `Build and push`, capture version IDs currently tagged `:pr-<N>` into a step output. After the push succeeds, re-query and delete only IDs in `pre \ post` (set difference). GHCR now holds exactly one image per active PR.

**2. Stop leaking child manifests on every delete (closes #33)**
GHCR doesn't cascade-delete the per-arch image manifests and provenance attestation manifests referenced by a multi-arch manifest list. With our build (`docker/build-push-action@v6`, `linux/amd64,linux/arm64`, default provenance), every parent has 4 children, so every deleted parent leaked 4 untagged versions.

After: factored the manifest-walk + delete logic into `.github/scripts/sweep-ghcr-versions.sh`, shared by both the build-time predecessor sweep and the on-close cleanup. For each parent to delete, walk its manifest via the GHCR registry API, resolve child digests to version IDs via a snapshot of the versions API, and delete children + parent in one pass.

## Implementation notes
- Single-arch manifests (no `.manifests` array) and registry 404s on the manifest fetch degrade gracefully to parent-only delete with a warning.
- Other registry/API errors fail the job loudly rather than swallowing them (no blanket `|| true`).
- The on-close cleanup gains a sparse checkout of `.github/scripts/` so the script is available.
- All three points from the Copilot review on the initial commit are folded in: null-safe jq filter, fail-on-non-404 for the package-versions API, and the post-push re-query to handle same-digest rebuilds.

## Version
None — workflow / scripts only, nothing ships in the image.

## Test plan
- [x] YAML parses
- [x] Script syntax-checks
- [x] Manifest-walk smoke-tested against live GHCR state for `v1.6.4` (parent → 4 expected child IDs)
- [x] Script handles empty stdin without error
- [x] Merge, push a follow-up commit to any open PR, confirm only one tagged version remains AND no untagged orphan accumulation
- [ ] Close a PR, confirm the final tagged version AND all 4 of its children are deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)