### PR TITLE
chore(footer): add labelle-org migration banner

### DIFF
--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -60,6 +60,28 @@ export function Footer() {
 
   return (
     <footer className="mt-8 text-center text-xs text-gray-400">
+      <div className="mx-auto mb-3 max-w-2xl rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-amber-900">
+        <strong>Heads up:</strong> labelle-web has moved to{" "}
+        <a
+          href="https://github.com/labelle-org/labelle-web"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-medium underline hover:text-amber-700"
+        >
+          labelle-org/labelle-web
+        </a>
+        . Update <code>compose.yaml</code> to pull{" "}
+        <code>ghcr.io/labelle-org/labelle-web:latest</code>.{" "}
+        <a
+          href="https://github.com/labelle-org/labelle/issues/139"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline hover:text-amber-700"
+        >
+          Context
+        </a>
+        .
+      </div>
       <a href={REPO_URL} target="_blank" rel="noopener noreferrer" className="hover:text-gray-600">
         Labelle Web
       </a>{" "}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labelle-web",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "private": true,
   "description": "Web interface for labelle DYMO label printers",
   "scripts": {


### PR DESCRIPTION
## Summary

Prep PR #1 of 2 for the transfer to `labelle-org/labelle-web` (see labelle-org/labelle#139).

Adds a one-time banner above the existing footer so the final release on `ghcr.io/szrudi/labelle-web` carries a visible "we've moved" notice for anyone still pulling `:latest` from the old namespace after the transfer.

## Scope (intentionally minimal)

- `client/src/components/Footer.tsx` — banner JSX above the existing version line. No other URLs changed.
- `package.json` — `1.6.5` → `1.6.6` (PATCH — transient banner, no new feature; removed in the cleanup PR).

## Why not bundle the URL/registry swaps?

- `compose.yaml`, README badge/registry mention, and `Footer.REPO_URL` still point at `szrudi/labelle-web` — they keep working pre-transfer, and `github.com` URLs auto 301-redirect after transfer.
- `ghcr.io` does **not** redirect — packages don't follow repo transfers. Updating `compose.yaml` to `ghcr.io/labelle-org/labelle-web:latest` before that image exists would cause `manifest unknown` errors for anyone running `docker compose pull`.
- The cleanup PR (#35, stacked on this one) handles the URL/registry swaps + banner removal in one shot, merged on `labelle-org/labelle-web` after the transfer, when the new-namespace image becomes the first post-transfer release.

## How existing Docker installs migrate

Existing `compose.yaml` files on users' hosts won't auto-update — Docker registries don't redirect. After this PR releases, existing installs pin to the final `ghcr.io/szrudi/labelle-web:1.6.6` image (with banner visible in the UI). Users update their `compose.yaml` manually when they notice the banner.

## Sequencing

1. ✅ #36 merged (uhubctl + DYMO console cleanup, `1.6.4 → 1.6.5`).
2. **Merge this PR** → `release.yml` cuts `v1.6.6` and publishes the final `ghcr.io/szrudi/labelle-web:1.6.6` + `:latest` (with banner baked in).
3. **Transfer** `szrudi/labelle-web` → `labelle-org/labelle-web`.
4. **Rebase + merge** #35 on the new repo → first release on `ghcr.io/labelle-org/labelle-web`, banner gone.

## Test plan

- [ ] CI green (PR image build + smoke)
- [ ] Spot-check the banner renders correctly
- [ ] Confirm `release.yml` will fire on merge (version changed from `1.6.5` → `1.6.6`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)