### PR TITLE
chore(transfer): point repo references to labelle-org/labelle-web

### DIFF
--- a/.github/release-notes/v1.7.0.md
+++ b/.github/release-notes/v1.7.0.md
@@ -1,0 +1,28 @@
+## Now part of labelle-org 🎉
+
+labelle-web is now an official project under [labelle-org](https://github.com/labelle-org), alongside the [labelle](https://github.com/labelle-org/labelle) library it builds on. Thanks @maresb for the invite — see [labelle-org/labelle#139](https://github.com/labelle-org/labelle/issues/139) for the backstory.
+
+### What this means for your install
+
+If your `compose.yaml` still references `ghcr.io/szrudi/labelle-web`, update it to the new namespace:
+
+```yaml
+services:
+  labelle-web:
+    image: ghcr.io/labelle-org/labelle-web:latest
+```
+
+Then `docker compose pull && docker compose up -d` will bring in this release and every future one.
+
+### If you don't update right away
+
+Nothing breaks. The final szrudi-namespace image (`ghcr.io/szrudi/labelle-web:1.6.6`) keeps working indefinitely. Its footer shows a "we've moved" banner so you know when you're on the old track — but no new releases will land there.
+
+### What changed in the code
+
+- The migration banner that v1.6.6 introduced is removed.
+- Every `szrudi/labelle-web` reference in `compose.yaml`, README, and in-app links is updated to `labelle-org/labelle-web`.
+
+Functionally identical to v1.6.6 minus the banner.
+
+---

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Labelle Web
 
-[![Tests](https://github.com/szrudi/labelle-web/actions/workflows/test.yml/badge.svg)](https://github.com/szrudi/labelle-web/actions/workflows/test.yml)
+[![Tests](https://github.com/labelle-org/labelle-web/actions/workflows/test.yml/badge.svg)](https://github.com/labelle-org/labelle-web/actions/workflows/test.yml)
 
 A web interface for [labelle](https://github.com/labelle-org/labelle) DYMO label printers. Compose labels with text, QR codes, barcodes, and images in your browser, with a live server-side preview and one-click printing.
 
@@ -50,7 +50,7 @@ docker compose up -d
 
 The app will be available at `http://<host>:5000`.
 
-Pre-built images for **amd64** and **arm64** (Raspberry Pi) are published to `ghcr.io/szrudi/labelle-web`. The `compose.yaml` pulls the latest image by default; if you'd rather build locally, run `docker compose up -d --build`.
+Pre-built images for **amd64** and **arm64** (Raspberry Pi) are published to `ghcr.io/labelle-org/labelle-web`. The `compose.yaml` pulls the latest image by default; if you'd rather build locally, run `docker compose up -d --build`.
 
 The container includes Python and the labelle library -- no host-level Python installation needed. USB passthrough is configured in `compose.yaml` so the container can talk to your DYMO printer.
 

--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-const REPO_URL = "https://github.com/szrudi/labelle-web";
+const REPO_URL = "https://github.com/labelle-org/labelle-web";
 
 interface HealthInfo {
   version: string;
@@ -35,7 +35,7 @@ export function Footer() {
   useEffect(() => {
     if (!health?.version || !onMain) return;
     const controller = new AbortController();
-    fetch("https://api.github.com/repos/szrudi/labelle-web/releases/latest", {
+    fetch("https://api.github.com/repos/labelle-org/labelle-web/releases/latest", {
       signal: controller.signal,
     })
       .then((res) => (res.ok ? res.json() : null))
@@ -60,28 +60,6 @@ export function Footer() {
 
   return (
     <footer className="mt-8 text-center text-xs text-gray-400">
-      <div className="mx-auto mb-3 max-w-2xl rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-amber-900">
-        <strong>Heads up:</strong> labelle-web has moved to{" "}
-        <a
-          href="https://github.com/labelle-org/labelle-web"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="font-medium underline hover:text-amber-700"
-        >
-          labelle-org/labelle-web
-        </a>
-        . Update <code>compose.yaml</code> to pull{" "}
-        <code>ghcr.io/labelle-org/labelle-web:latest</code>.{" "}
-        <a
-          href="https://github.com/labelle-org/labelle/issues/139"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="underline hover:text-amber-700"
-        >
-          Context
-        </a>
-        .
-      </div>
       <a href={REPO_URL} target="_blank" rel="noopener noreferrer" className="hover:text-gray-600">
         Labelle Web
       </a>{" "}

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   labelle-web:
-    image: ghcr.io/szrudi/labelle-web:latest
+    image: ghcr.io/labelle-org/labelle-web:latest
     build:
       context: .
       args:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labelle-web",
-  "version": "1.6.6",
+  "version": "1.7.0",
   "private": true,
   "description": "Web interface for labelle DYMO label printers",
   "scripts": {


### PR DESCRIPTION
## Summary

Cleanup PR — first commit on the labelle-org repo. Removes the migration banner that the final szrudi-namespace release (v1.6.6) shipped, and swaps every remaining `szrudi/labelle-web` reference to `labelle-org/labelle-web`. Merging triggers the **first release on the new GHCR namespace**, `ghcr.io/labelle-org/labelle-web:1.7.0`.

## Changes

- `compose.yaml` — `ghcr.io/szrudi/labelle-web:latest` → `ghcr.io/labelle-org/labelle-web:latest`
- `README.md` — Tests badge URL + GHCR registry mention
- `client/src/components/Footer.tsx` — remove migration banner; `REPO_URL` and the releases-check API URL → `labelle-org/labelle-web`
- `package.json` — `1.6.6` → `1.7.0` (MINOR — symbolic marker for the namespace transition, and existing installs need a `compose.yaml` edit to keep receiving updates)
- `.github/release-notes/v1.7.0.md` — user-facing migration announcement shipped as the v1.7.0 release body

## Sequencing recap

1. ✅ #36 merged → `v1.6.5` shipped (server console cleanup)
2. ✅ #34 merged → `v1.6.6` shipped to `ghcr.io/szrudi/labelle-web` with migration banner
3. ✅ Repo transferred from `szrudi/labelle-web` to `labelle-org/labelle-web`
4. ⏭ **Merge this PR** → `release.yml` cuts `v1.7.0` and publishes the first image to `ghcr.io/labelle-org/labelle-web`
5. ⏭ Make the new GHCR package public on labelle-org's package settings

## Test plan

- [ ] CI green on labelle-org repo
- [ ] Spot-check footer renders without the banner
- [ ] Confirm `release.yml` fires and pushes to `ghcr.io/labelle-org/labelle-web:1.7.0`
- [ ] Confirm the release body reads from `.github/release-notes/v1.7.0.md` (announcement renders correctly on the release page)
- [ ] Make the GHCR package public on labelle-org

🤖 Generated with [Claude Code](https://claude.com/claude-code)