### PR TITLE
feat: key real printers by serial number, not the volatile USB id — closes #40

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -126,7 +126,10 @@ The backend supports two types of printers:
 
 #### Real USB Printers
 - Detected via `DeviceManager().scan()` from labelle library
-- Identified by USB bus/address (e.g. "Bus 001 Device 005: ID 0922:1234")
+- Identified by serial number (`serial:<sn>`) when the device reports one,
+  falling back to the USB bus/address (`Bus 001 Device 005: ID 0922:1234`)
+  only when it doesn't. The serial is stable across re-enumeration (replug,
+  reboot, USB power-cycle); the bus/address is not. See `_printer_id`.
 - Send output directly to USB device via labelle's `DymoLabeler.print()`
 
 #### Virtual Printers
@@ -136,7 +139,7 @@ The backend supports two types of printers:
 - Useful for testing, archiving, and development without hardware
 
 **Printer ID Format:**
-- Real printers: Full USB ID string from device manager
+- Real printers: `serial:{serial_number}`, or the full USB bus/address ID string when the device reports no serial
 - Virtual printers: `virtual:{name}` where name has spaces/special chars replaced with underscores
 
 **Output Filename Format (virtual printers):** `label_YYYYMMDD_HHMMSS_uuid.png`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labelle-web",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "private": true,
   "description": "Web interface for labelle DYMO label printers",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labelle-web",
-  "version": "1.8.0",
+  "version": "1.7.0",
   "private": true,
   "description": "Web interface for labelle DYMO label printers",
   "scripts": {

--- a/server/printer_service.py
+++ b/server/printer_service.py
@@ -19,6 +19,24 @@ logger = logging.getLogger(__name__)
 # which re-energizes off ports).
 
 
+def _printer_id(dev) -> str:
+    """Stable id for a real USB printer.
+
+    Prefer the device serial number: it survives re-enumeration (replug,
+    reboot, and this app's own USB power-cycling), whereas labelle's
+    `usb_id` embeds the kernel-assigned Bus/Device address, which changes
+    on every re-enumeration and would orphan that printer's saved settings.
+    Fall back to `usb_id` only when the device reports no serial. See #40.
+
+    Used both when listing printers and when resolving a print request's
+    printer_id back to a device, so the two always agree.
+    """
+    serial = dev.serial_number
+    if serial:
+        return f"serial:{serial}"
+    return dev.usb_id
+
+
 def _find_virtual_printer(printer_id: str) -> VirtualPrinter:
     """Resolve a virtual printer by its ID (e.g. 'virtual:Office_Printer')."""
     for config in get_virtual_printers():
@@ -64,7 +82,7 @@ def list_printers() -> list[dict]:
             name = " ".join(parts) if parts else dev.usb_id
 
             printers.append({
-                "id": dev.usb_id,
+                "id": _printer_id(dev),
                 "name": name,
                 "vendorProductId": dev.vendor_product_id,
                 "serialNumber": dev.serial_number,
@@ -102,9 +120,10 @@ def print_label(
         widgets: List of widget dictionaries to render
         settings: Label settings (tape size, margins, etc.)
         upload_dir: Directory where uploaded images are stored
-        printer_id: Optional printer ID. Can be:
-                   - USB ID (e.g. "Bus 001 Device 005: ID 0922:1234") for real printer
-                   - virtual:name (e.g. "virtual:Office_Printer") for virtual printer
+        printer_id: Optional printer ID (see _printer_id). Can be:
+                   - "serial:<sn>" for a real printer reporting a serial
+                     (falls back to "Bus NNN Device NNN: ID vvvv:pppp" if not)
+                   - "virtual:<name>" for a virtual printer
                    - None to auto-select first available real printer
     """
     # Virtual printer request
@@ -120,9 +139,8 @@ def print_label(
         device_manager = DeviceManager()
         device_manager.scan()
 
-        # TODO: Future improvement - store per-printer settings (tape size, margins, color)
         if printer_id:
-            matching_devices = [dev for dev in device_manager.devices if dev.usb_id == printer_id]
+            matching_devices = [dev for dev in device_manager.devices if _printer_id(dev) == printer_id]
             if not matching_devices:
                 raise ValueError(f"Printer not found: {printer_id}")
             device = matching_devices[0]
@@ -200,7 +218,7 @@ def print_bitmap(
         device_manager = DeviceManager()
         device_manager.scan()
         if printer_id:
-            matching = [d for d in device_manager.devices if d.usb_id == printer_id]
+            matching = [d for d in device_manager.devices if _printer_id(d) == printer_id]
             if not matching:
                 raise ValueError(f"Printer not found: {printer_id}")
             device = matching[0]

--- a/server/tests/test_printer_service.py
+++ b/server/tests/test_printer_service.py
@@ -24,6 +24,74 @@ def sample_settings():
     }
 
 
+def _fake_device(serial="08383504012013", usb_id="Bus 001 Device 005: ID 0922:1002"):
+    dev = MagicMock()
+    dev.serial_number = serial
+    dev.usb_id = usb_id
+    dev.vendor_product_id = "0922:1002"
+    dev.manufacturer = "DYMO"
+    dev.product = "LabelManager PnP"
+    return dev
+
+
+class TestStablePrinterId:
+    """Real-printer ids must be keyed by serial (stable across
+    re-enumeration), falling back to usb_id only when no serial. See #40."""
+
+    def test_uses_serial_when_present(self):
+        from printer_service import _printer_id
+
+        assert _printer_id(_fake_device(serial="ABC123")) == "serial:ABC123"
+
+    def test_falls_back_to_usb_id_when_no_serial(self):
+        from printer_service import _printer_id
+
+        dev = _fake_device(serial=None, usb_id="Bus 001 Device 005: ID 0922:1002")
+        assert _printer_id(dev) == "Bus 001 Device 005: ID 0922:1002"
+
+    @patch("printer_service.DeviceManager")
+    def test_list_printers_emits_serial_based_id(self, mock_dm_cls, no_virtual_printers_env):
+        mock_dm = MagicMock()
+        mock_dm.devices = [_fake_device(serial="ABC123")]
+        mock_dm_cls.return_value = mock_dm
+
+        from printer_service import list_printers
+
+        real = [p for p in list_printers() if p["vendorProductId"] == "0922:1002"]
+        assert real[0]["id"] == "serial:ABC123"
+
+    @patch("printer_service.render_payload")
+    @patch("printer_service.DymoLabeler")
+    @patch("printer_service.DeviceManager")
+    def test_print_resolves_device_by_serial_id(
+        self, mock_dm_cls, mock_labeler_cls, mock_render, sample_widgets, sample_settings
+    ):
+        dev = _fake_device(serial="ABC123")
+        mock_dm = MagicMock()
+        mock_dm.devices = [dev]
+        mock_dm_cls.return_value = mock_dm
+
+        from printer_service import print_label
+
+        # The same id list_printers emits must resolve back to the device.
+        print_label(sample_widgets, sample_settings, printer_id="serial:ABC123")
+        dev.setup.assert_called_once()
+        mock_labeler_cls.return_value.print.assert_called_once()
+
+    @patch("printer_service.DeviceManager")
+    def test_print_raises_when_serial_id_does_not_match(
+        self, mock_dm_cls, sample_widgets, sample_settings
+    ):
+        mock_dm = MagicMock()
+        mock_dm.devices = [_fake_device(serial="ABC123")]
+        mock_dm_cls.return_value = mock_dm
+
+        from printer_service import print_label
+
+        with pytest.raises(ValueError, match="Printer not found"):
+            print_label(sample_widgets, sample_settings, printer_id="serial:NOPE")
+
+
 class TestListPrinters:
     @patch("printer_service.DeviceManager")
     def test_returns_virtual_printers(self, mock_dm_cls, virtual_printer_env):


### PR DESCRIPTION
Closes #40.

## Why

A real printer's `PrinterInfo.id` was labelle's `usb_id`:

```python
f"Bus {bus:03} Device {address:03}: ID {vendor_product_id}"
```

`address` is the **kernel-assigned USB device address, reassigned on every re-enumeration** — replug, reboot, and (critically) this app's own USB power-save cycle (power off when idle → on at page load). Keying anything by it means the identity drifts constantly on the Pi deployment.

## What

`_printer_id(dev)`: prefer **`serial:<serial_number>`** (stable across re-enumeration — the Dymo LabelManager PnP reports one), fall back to the `usb_id` only when no serial is present. Used in **both** places that matter so they always agree:
- `list_printers()` — the id emitted to the client,
- `print_label` / `print_bitmap` — resolving a request's `printer_id` back to a device.

USB power feature is untouched (keyed by hub/port via VID:PID). Virtual printers untouched (`virtual:<name>` already stable). Client is untouched — the id is opaque to it.

## Why now (stacked under the per-printer-settings PR)

This is the **stable-identity foundation** that makes per-printer settings (#20, PR #39) actually durable on the hardware — otherwise saved settings would orphan after each idle power-off→on. PR #39 will rebase on top of this and key off the stable id for free. Also feeds the status/alias work in #38.

## Tests

`_printer_id` serial vs usb_id-fallback; `list_printers` emits the serial id; print resolves a device by its serial id and raises on a non-match. Full backend suite green (223).

## Versioning

**None** — stacked under #39; left at `1.7.0` so merging triggers no separate release. Ships in the single **v1.8.0** that #39 cuts.

## Note

Edge case left as documented behavior: a device reporting no serial falls back to the volatile usb_id (unavoidable without a serial), and two devices reporting identical serials would collide — neither applies to the single Dymo target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)