### PR TITLE
feat: stable virtual printer ids — optional explicit id + safe slug — closes #42

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Each printer configuration has the following fields:
 - `name`: Display name (will appear as "{name} (Virtual)" in UI)
 - `path`: Directory where output will be saved (created automatically)
 - `output` *(optional)*: What to save — `"image"` (default), `"json"`, or `"both"`. `"image"` saves a color preview PNG, `"json"` saves the label data for re-importing later.
+- `id` *(optional)*: A stable identifier (URL-safe `[A-Za-z0-9_-]`) decoupled from the display name. Set it if you want a printer's saved settings to survive renaming it; otherwise the id is derived from the name. Entries with a colliding id are skipped.
 
 ```bash
 # Example with output mode:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -134,13 +134,13 @@ The backend supports two types of printers:
 
 #### Virtual Printers
 - Configured via `VIRTUAL_PRINTERS` environment variable
-- Identified by `virtual:{sanitized_name}` format (e.g. "virtual:Office_Printer")
+- Identified by `virtual:{id}` — an optional explicit `id` from config (stable, decoupled from the display name), else a path-safe slug of the name (e.g. "virtual:Office_Printer")
 - Save labels as PNG files to configured directories
 - Useful for testing, archiving, and development without hardware
 
 **Printer ID Format:**
 - Real printers: `serial:{serial_number}`, or the full USB bus/address ID string when the device reports no serial
-- Virtual printers: `virtual:{name}` where name has spaces/special chars replaced with underscores
+- Virtual printers: `virtual:{id}` — the optional config `id` (URL-safe `[A-Za-z0-9_-]`), else a path-safe slug of the name (non-word runs → `_`). Colliding ids are rejected at config load.
 
 **Output Filename Format (virtual printers):** `label_YYYYMMDD_HHMMSS_uuid.png`
 
@@ -334,6 +334,8 @@ export VIRTUAL_PRINTERS='[
   {"name":"Warehouse Printer","path":"./output/warehouse"}
 ]'
 ```
+
+Each entry takes `name` and `path`, plus optional `output` (`image` (default) / `json` / `both`) and an optional `id`. Set `id` (URL-safe `[A-Za-z0-9_-]`) to give a printer a stable identity decoupled from its display name — its saved per-printer settings then survive renaming the `name`. Without `id`, the id is slugged from the name; entries whose ids collide are skipped at load with a warning.
 
 In Docker, configure in `.env` (loaded via `env_file` in `compose.yaml`):
 ```bash

--- a/server/config.py
+++ b/server/config.py
@@ -52,6 +52,11 @@ def get_virtual_printers() -> list[dict]:
             if "name" not in printer or "path" not in printer:
                 LOG.warning(f"Virtual printer missing 'name' or 'path': {printer}")
                 continue
+            if not isinstance(printer["name"], str) or not isinstance(printer["path"], str):
+                # Skip rather than letting a non-string name/path crash id
+                # computation (re.sub) or directory creation downstream.
+                LOG.warning(f"Virtual printer 'name' and 'path' must be strings: {printer}")
+                continue
 
             output = printer.get("output", "image")
             if output not in VALID_OUTPUT_MODES:

--- a/server/config.py
+++ b/server/config.py
@@ -7,6 +7,8 @@ import json
 import logging
 import os
 
+from virtual_printer import compute_virtual_id, is_valid_virtual_id
+
 LOG = logging.getLogger(__name__)
 
 VALID_OUTPUT_MODES = {"image", "json", "both"}
@@ -15,10 +17,16 @@ VALID_OUTPUT_MODES = {"image", "json", "both"}
 def get_virtual_printers() -> list[dict]:
     """Load virtual printer configuration from VIRTUAL_PRINTERS environment variable.
 
-    Expected format: JSON array of objects with 'name', 'path', and optional 'output' fields.
-    Example: [{"name": "Office Printer", "path": "./output/office", "output": "both"}]
+    Expected format: JSON array of objects with 'name' and 'path', plus optional
+    'output' and 'id' fields.
+    Example: [{"name": "Office Printer", "path": "./output/office", "output": "both", "id": "office"}]
 
     The 'output' field controls what files are saved: "image" (default), "json", or "both".
+
+    The optional 'id' gives the printer a stable identity (URL-safe
+    [A-Za-z0-9_-]) decoupled from its display name; when omitted the id is
+    slugged from the name. Entries with an invalid or colliding id are
+    skipped with a warning. See #42.
 
     Returns:
         List of virtual printer configuration dictionaries.
@@ -36,6 +44,7 @@ def get_virtual_printers() -> list[dict]:
 
         # Validate structure
         valid_printers = []
+        seen_ids: dict[str, str] = {}
         for printer in printers:
             if not isinstance(printer, dict):
                 LOG.warning(f"Skipping invalid virtual printer config: {printer}")
@@ -49,6 +58,28 @@ def get_virtual_printers() -> list[dict]:
                 LOG.warning(f"Invalid output mode '{output}' for virtual printer '{printer['name']}' (must be one of {VALID_OUTPUT_MODES})")
                 continue
             printer.setdefault("output", "image")
+
+            # Optional explicit id (stable, decoupled from the name). Must be
+            # URL-safe since it travels in the settings route path. See #42.
+            explicit_id = printer.get("id")
+            if explicit_id is not None and not is_valid_virtual_id(explicit_id):
+                LOG.warning(
+                    f"Skipping virtual printer '{printer['name']}': id {explicit_id!r} "
+                    "must be a non-empty string of [A-Za-z0-9_-]"
+                )
+                continue
+
+            # Reject ids that collide with an earlier entry — otherwise both
+            # would share one settings entry and the second would be shadowed
+            # at print time (_find_virtual_printer returns the first match).
+            pid = compute_virtual_id(printer["name"], explicit_id)
+            if pid in seen_ids:
+                LOG.warning(
+                    f"Skipping virtual printer '{printer['name']}': id '{pid}' "
+                    f"collides with earlier printer '{seen_ids[pid]}'"
+                )
+                continue
+            seen_ids[pid] = printer["name"]
 
             valid_printers.append(printer)
 

--- a/server/printer_service.py
+++ b/server/printer_service.py
@@ -40,7 +40,7 @@ def _printer_id(dev) -> str:
 def _find_virtual_printer(printer_id: str) -> VirtualPrinter:
     """Resolve a virtual printer by its ID (e.g. 'virtual:Office_Printer')."""
     for config in get_virtual_printers():
-        vp = VirtualPrinter(config["name"], config["path"], output_mode=config.get("output", "image"))
+        vp = VirtualPrinter.from_config(config)
         if vp.id == printer_id:
             return vp
     raise ValueError(f"Virtual printer not found: {printer_id}")
@@ -52,8 +52,7 @@ def _fallback_to_virtual(widgets: list[dict], settings: dict, upload_dir: str) -
     if not virtual_printers_config:
         raise ValueError("No printers available (no USB printers found and no virtual printers configured)")
 
-    config = virtual_printers_config[0]
-    vp = VirtualPrinter(config["name"], config["path"], output_mode=config.get("output", "image"))
+    vp = VirtualPrinter.from_config(virtual_printers_config[0])
     preview_bitmap = render_preview(widgets, settings, upload_dir)
     vp.save(preview_bitmap, widgets, settings)
 
@@ -98,7 +97,7 @@ def list_printers() -> list[dict]:
     # Add virtual printers from configuration
     try:
         for config in get_virtual_printers():
-            virtual = VirtualPrinter(config["name"], config["path"], output_mode=config.get("output", "image"))
+            virtual = VirtualPrinter.from_config(config)
             printers.append({
                 "id": virtual.id,
                 "name": virtual.display_name,
@@ -179,10 +178,7 @@ def _fallback_to_virtual_bitmap(
         raise ValueError(
             "No printers available (no USB printers found and no virtual printers configured)"
         )
-    config = virtual_printers_config[0]
-    vp = VirtualPrinter(
-        config["name"], config["path"], output_mode=config.get("output", "image")
-    )
+    vp = VirtualPrinter.from_config(virtual_printers_config[0])
     vp.save(_bitmap_to_viewable(bitmap), widgets, settings)
 
 

--- a/server/tests/test_config.py
+++ b/server/tests/test_config.py
@@ -64,6 +64,22 @@ class TestGetVirtualPrinters:
         assert len(result) == 1
         assert result[0]["name"] == "A"
 
+    def test_non_string_name_is_skipped_not_crash(self):
+        # A non-string name must not crash id computation (re.sub); skip it.
+        config = [
+            {"name": 123, "path": "/tmp/a"},
+            {"name": "Good", "path": "/tmp/b"},
+        ]
+        self._set_env(json.dumps(config))
+        result = get_virtual_printers()
+        assert len(result) == 1
+        assert result[0]["name"] == "Good"
+
+    def test_non_string_path_is_skipped(self):
+        config = [{"name": "X", "path": 5}]
+        self._set_env(json.dumps(config))
+        assert get_virtual_printers() == []
+
     def test_empty_env_var(self):
         self._set_env("")
         result = get_virtual_printers()

--- a/server/tests/test_config.py
+++ b/server/tests/test_config.py
@@ -31,6 +31,39 @@ class TestGetVirtualPrinters:
         result = get_virtual_printers()
         assert len(result) == 2
 
+    def test_explicit_id_is_kept(self):
+        config = [{"id": "office", "name": "Office (2nd Floor)", "path": "/tmp/o"}]
+        self._set_env(json.dumps(config))
+        result = get_virtual_printers()
+        assert len(result) == 1
+        assert result[0]["id"] == "office"
+
+    def test_invalid_explicit_id_is_skipped(self):
+        config = [{"id": "bad/id", "name": "Office", "path": "/tmp/o"}]
+        self._set_env(json.dumps(config))
+        assert get_virtual_printers() == []
+
+    def test_colliding_derived_ids_skip_the_later(self):
+        # Both names slug to virtual:Office_Floor_2 — keep the first only.
+        config = [
+            {"name": "Office Floor 2", "path": "/tmp/a"},
+            {"name": "Office (Floor 2)", "path": "/tmp/b"},
+        ]
+        self._set_env(json.dumps(config))
+        result = get_virtual_printers()
+        assert len(result) == 1
+        assert result[0]["path"] == "/tmp/a"
+
+    def test_colliding_explicit_id_skips_the_later(self):
+        config = [
+            {"id": "shared", "name": "A", "path": "/tmp/a"},
+            {"id": "shared", "name": "B", "path": "/tmp/b"},
+        ]
+        self._set_env(json.dumps(config))
+        result = get_virtual_printers()
+        assert len(result) == 1
+        assert result[0]["name"] == "A"
+
     def test_empty_env_var(self):
         self._set_env("")
         result = get_virtual_printers()

--- a/server/tests/test_virtual_printer.py
+++ b/server/tests/test_virtual_printer.py
@@ -24,25 +24,50 @@ class TestVirtualPrinterId:
         vp = VirtualPrinter("Printer", "/tmp/test")
         assert vp.id.startswith("virtual:")
 
-    def test_slashes_preserved(self):
+    def test_slashes_sanitized(self):
+        # Slashes would split the settings route path — must not survive. (#42)
         vp = VirtualPrinter("Floor/2", "/tmp/test")
-        assert vp.id == "virtual:Floor/2"
+        assert vp.id == "virtual:Floor_2"
 
-    def test_dots_preserved(self):
+    def test_dots_sanitized(self):
         vp = VirtualPrinter("v2.0 Printer", "/tmp/test")
-        assert vp.id == "virtual:v2.0_Printer"
+        assert vp.id == "virtual:v2_0_Printer"
 
-    def test_unicode_name(self):
+    def test_unicode_letters_preserved(self):
+        # Unicode letters are \w and %-encode fine in a URL path.
         vp = VirtualPrinter("Drucker Büro", "/tmp/test")
         assert vp.id == "virtual:Drucker_Büro"
 
-    def test_emoji_name(self):
+    def test_emoji_stripped(self):
         vp = VirtualPrinter("Printer 🖨️", "/tmp/test")
-        assert vp.id == "virtual:Printer_🖨️"
+        assert vp.id == "virtual:Printer"
 
-    def test_empty_name(self):
+    def test_empty_name_falls_back(self):
         vp = VirtualPrinter("", "/tmp/test")
-        assert vp.id == "virtual:"
+        assert vp.id == "virtual:printer"
+
+
+class TestVirtualPrinterExplicitId:
+    def test_explicit_id_overrides_name(self):
+        vp = VirtualPrinter("Office (2nd Floor)", "/tmp/test", printer_id="office")
+        assert vp.id == "virtual:office"
+
+    def test_explicit_id_is_decoupled_from_display_name(self):
+        # Renaming the display name must not change the id.
+        vp = VirtualPrinter("Renamed", "/tmp/test", printer_id="office")
+        assert vp.id == "virtual:office"
+        assert vp.display_name == "Renamed (Virtual)"
+
+    def test_from_config_honors_id_and_output(self):
+        vp = VirtualPrinter.from_config(
+            {"name": "X", "path": "/tmp/test", "output": "both", "id": "x1"}
+        )
+        assert vp.id == "virtual:x1"
+        assert vp.output_mode == "both"
+
+    def test_from_config_without_id_slugs_name(self):
+        vp = VirtualPrinter.from_config({"name": "Floor/2", "path": "/tmp/test"})
+        assert vp.id == "virtual:Floor_2"
 
 
 class TestVirtualPrinterDisplayName:

--- a/server/tests/test_virtual_printer.py
+++ b/server/tests/test_virtual_printer.py
@@ -4,7 +4,21 @@ import os
 import pytest
 from PIL import Image
 
-from virtual_printer import VirtualPrinter
+from virtual_printer import VirtualPrinter, is_valid_virtual_id
+
+
+class TestIsValidVirtualId:
+    def test_accepts_url_safe(self):
+        assert is_valid_virtual_id("office_2-A")
+
+    def test_rejects_trailing_newline(self):
+        # `$` would match before the newline; fullmatch must not. (#42)
+        assert not is_valid_virtual_id("office\n")
+
+    def test_rejects_slash_and_empty_and_non_str(self):
+        assert not is_valid_virtual_id("a/b")
+        assert not is_valid_virtual_id("")
+        assert not is_valid_virtual_id(123)
 
 
 class TestVirtualPrinterId:

--- a/server/virtual_printer.py
+++ b/server/virtual_printer.py
@@ -18,8 +18,9 @@ from PIL import Image
 LOG = logging.getLogger(__name__)
 
 # A virtual printer id suffix must be URL-safe: it travels in the
-# /api/printers/<path:printer_id>/settings route. See #42.
-_VIRTUAL_ID_CHARSET = re.compile(r"^[A-Za-z0-9_-]+$")
+# /api/printers/<path:printer_id>/settings route. Matched with fullmatch
+# (not $, which also matches before a trailing newline). See #42.
+_VIRTUAL_ID_CHARSET = re.compile(r"[A-Za-z0-9_-]+")
 
 
 def slugify_printer_name(name: str) -> str:
@@ -46,8 +47,11 @@ def compute_virtual_id(name: str, explicit_id: str | None = None) -> str:
 
 
 def is_valid_virtual_id(value) -> bool:
-    """Whether an explicit config id is a non-empty URL-safe string."""
-    return isinstance(value, str) and bool(_VIRTUAL_ID_CHARSET.match(value))
+    """Whether an explicit config id is a non-empty URL-safe string.
+
+    fullmatch (not match) so a trailing newline can't sneak through — `$`
+    matches before a final `\\n`, `fullmatch` requires the whole string."""
+    return isinstance(value, str) and bool(_VIRTUAL_ID_CHARSET.fullmatch(value))
 
 
 class VirtualPrinter:

--- a/server/virtual_printer.py
+++ b/server/virtual_printer.py
@@ -9,6 +9,7 @@ import datetime
 import json
 import logging
 import os
+import re
 import uuid
 from pathlib import Path
 
@@ -16,13 +17,51 @@ from PIL import Image
 
 LOG = logging.getLogger(__name__)
 
+# A virtual printer id suffix must be URL-safe: it travels in the
+# /api/printers/<path:printer_id>/settings route. See #42.
+_VIRTUAL_ID_CHARSET = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def slugify_printer_name(name: str) -> str:
+    """Derive a path-safe id suffix from a printer name.
+
+    Collapses any run of non-word characters (anything outside letters,
+    digits, `_`, `-` — `\\w` keeps Unicode letters, which `%`-encode fine
+    in a URL path) to a single `_` and trims leading/trailing `_`. The
+    point is to drop path-hostile characters like `/`. Falls back to
+    "printer" for a name with no usable characters, so the id is never an
+    empty `virtual:` (a collision then surfaces via config validation)."""
+    slug = re.sub(r"[^\w-]+", "_", name).strip("_")
+    return slug or "printer"
+
+
+def compute_virtual_id(name: str, explicit_id: str | None = None) -> str:
+    """Full virtual printer id (`virtual:<suffix>`).
+
+    Uses an explicit id when given (stable, decoupled from the display
+    name; assumed already charset-validated by the config loader), else a
+    URL-safe slug of the name."""
+    suffix = explicit_id if explicit_id else slugify_printer_name(name)
+    return f"virtual:{suffix}"
+
+
+def is_valid_virtual_id(value) -> bool:
+    """Whether an explicit config id is a non-empty URL-safe string."""
+    return isinstance(value, str) and bool(_VIRTUAL_ID_CHARSET.match(value))
+
 
 class VirtualPrinter:
     """Virtual printer that saves labels as PNG and/or JSON files."""
 
     VALID_OUTPUT_MODES = ("image", "json", "both")
 
-    def __init__(self, name: str, output_path: str, output_mode: str = "image"):
+    def __init__(
+        self,
+        name: str,
+        output_path: str,
+        output_mode: str = "image",
+        printer_id: str | None = None,
+    ):
         if output_mode not in self.VALID_OUTPUT_MODES:
             raise ValueError(
                 f"Invalid output_mode '{output_mode}' for virtual printer '{name}'. "
@@ -31,7 +70,22 @@ class VirtualPrinter:
         self.name = name
         self.output_path = output_path
         self.output_mode = output_mode
+        # Optional stable id from config; when absent the id is slugged
+        # from the name. See compute_virtual_id / #42.
+        self._printer_id = printer_id
         self._ensure_output_directory()
+
+    @classmethod
+    def from_config(cls, config: dict) -> "VirtualPrinter":
+        """Build from a validated VIRTUAL_PRINTERS entry, honoring an
+        optional explicit `id`. Single construction path so every caller
+        resolves the same id."""
+        return cls(
+            config["name"],
+            config["path"],
+            output_mode=config.get("output", "image"),
+            printer_id=config.get("id"),
+        )
 
     def _ensure_output_directory(self):
         """Create output directory if it doesn't exist."""
@@ -43,9 +97,8 @@ class VirtualPrinter:
 
     @property
     def id(self) -> str:
-        """Get unique printer ID with virtual prefix."""
-        sanitized_name = self.name.replace(" ", "_").replace("(", "").replace(")", "")
-        return f"virtual:{sanitized_name}"
+        """Stable `virtual:<suffix>` id — explicit config id, else name slug."""
+        return compute_virtual_id(self.name, self._printer_id)
 
     @property
     def display_name(self) -> str:


### PR DESCRIPTION
Closes #42. Stacked under #39 (per-printer settings); **no version bump** — ships in the single v1.8.0 that #39 cuts.

## Why

Virtual ids were derived from the display name with a minimal sanitizer (spaces/parens only) and **no uniqueness check** (`virtual_printer.py`, `config.py`):
- distinct names could collide onto one id → shared settings + the second printer shadowed at print time;
- path-hostile characters (notably `/`) survived into the `/api/printers/<path:printer_id>/settings` route;
- the id changed whenever the display name was edited → saved settings orphaned.

## What

- **Optional explicit `id`** in `VIRTUAL_PRINTERS` entries → `virtual:<id>`: a stable, URL-safe identity decoupled from the display name (the virtual analog of #40's serial). Renaming `name` no longer orphans settings.
- **Path-safe slug fallback** when no `id`: collapse non-word runs to `_`, keep Unicode letters (they `%`-encode fine), fall back to `printer` for an empty result.
- **Config-load validation**: reject a non-URL-safe explicit `id` (`[A-Za-z0-9_-]`); skip an entry whose id **collides** with an earlier one — both warn.
- **`VirtualPrinter.from_config`**: single construction path, so the resolved id is consistent across listing, lookup, and printing (replaces 4 duplicated constructions).

## Compatibility

Existing `id`-less configs keep working via the slug. The slug differs from the old sanitizer only for path-hostile names (`/`, `.`, emoji) — acceptable, since per-printer settings (#20/#39) aren't released yet, so nothing durable re-keys. Existing tests asserting the old incidental behavior (`test_slashes_preserved` etc.) updated to the new contract.

## Tests

`virtual_printer` (slug cases, explicit id, `from_config`), `config` (explicit id kept, invalid skipped, derived + explicit collisions skipped). Full backend suite green (231); no import cycle from the new `config → virtual_printer` dependency (smoke imports all modules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)