### PR TITLE
feat: default printer selection to a real printer instead of Auto-select

### DIFF
--- a/client/src/components/SettingsBar.test.tsx
+++ b/client/src/components/SettingsBar.test.tsx
@@ -49,14 +49,13 @@ beforeEach(() => {
 
 describe("SettingsBar printer selector", () => {
   it("shows printer selector when multiple printers available", () => {
-    useLabelStore.setState({ availablePrinters: twoPrinters });
+    useLabelStore.getState().setAvailablePrinters(twoPrinters);
     render(<SettingsBar />);
 
     // Open the details
     screen.getByText("Settings").click();
 
     expect(screen.getByText("Printer")).toBeInTheDocument();
-    expect(screen.getByText("Auto-select")).toBeInTheDocument();
   });
 
   it("hides printer selector when 0 printers", () => {
@@ -77,50 +76,35 @@ describe("SettingsBar printer selector", () => {
     expect(screen.queryByText("Printer")).not.toBeInTheDocument();
   });
 
-  it("lists all printers plus Auto-select", () => {
-    useLabelStore.setState({ availablePrinters: twoPrinters });
+  it("lists all available printers (no Auto-select option)", () => {
+    useLabelStore.getState().setAvailablePrinters(twoPrinters);
     render(<SettingsBar />);
 
     screen.getByText("Settings").click();
 
-    const select = screen.getByDisplayValue("Auto-select");
+    // Defaults to the first printer; the "Auto-select" entry is gone.
+    const select = screen.getByDisplayValue("DYMO LabelWriter 450");
     const options = select.querySelectorAll("option");
+    expect(options).toHaveLength(2);
+    expect(options[0]!.textContent).toBe("DYMO LabelWriter 450");
+    expect(options[1]!.textContent).toBe("Office (Virtual)");
+  });
 
-    // Auto-select + 2 printers = 3 options
-    expect(options).toHaveLength(3);
-    expect(options[0]!.textContent).toBe("Auto-select");
-    expect(options[1]!.textContent).toBe("DYMO LabelWriter 450");
-    expect(options[2]!.textContent).toBe("Office (Virtual)");
+  it("defaults the selection to the first printer when the list loads", () => {
+    useLabelStore.getState().setAvailablePrinters(twoPrinters);
+    expect(useLabelStore.getState().settings.printerId).toBe("usb:1");
   });
 
   it("selecting a printer updates the store", async () => {
-    useLabelStore.setState({ availablePrinters: twoPrinters });
-    render(<SettingsBar />);
-
-    screen.getByText("Settings").click();
-
-    const select = screen.getByDisplayValue("Auto-select");
-    await userEvent.selectOptions(select, "virtual:Office");
-
-    expect(useLabelStore.getState().settings.printerId).toBe("virtual:Office");
-  });
-
-  it("selecting Auto-select clears printerId", async () => {
-    useLabelStore.setState({
-      availablePrinters: twoPrinters,
-      settings: {
-        ...useLabelStore.getState().settings,
-        printerId: "usb:1",
-      },
-    });
+    useLabelStore.getState().setAvailablePrinters(twoPrinters);
     render(<SettingsBar />);
 
     screen.getByText("Settings").click();
 
     const select = screen.getByDisplayValue("DYMO LabelWriter 450");
-    await userEvent.selectOptions(select, "");
+    await userEvent.selectOptions(select, "virtual:Office");
 
-    expect(useLabelStore.getState().settings.printerId).toBeUndefined();
+    expect(useLabelStore.getState().settings.printerId).toBe("virtual:Office");
   });
 });
 
@@ -138,7 +122,7 @@ describe("SettingsBar power toggle visibility", () => {
     });
   });
 
-  it("shows the power toggle on Auto-select (no printerId)", async () => {
+  it("shows the power toggle when no printer is resolved yet (no printerId)", async () => {
     useLabelStore.setState({
       availablePrinters: twoPrinters,
       settings: { ...useLabelStore.getState().settings, printerId: undefined },

--- a/client/src/components/SettingsBar.test.tsx
+++ b/client/src/components/SettingsBar.test.tsx
@@ -106,6 +106,19 @@ describe("SettingsBar printer selector", () => {
 
     expect(useLabelStore.getState().settings.printerId).toBe("virtual:Office");
   });
+
+  it("shows the first printer when printerId is unset (no blank value)", () => {
+    // printerId undefined but multiple printers present (e.g. transiently
+    // after an import) — the select must display a real option, not blank.
+    useLabelStore.setState({
+      availablePrinters: twoPrinters,
+      settings: { ...useLabelStore.getState().settings, printerId: undefined },
+    });
+    render(<SettingsBar />);
+    screen.getByText("Settings").click();
+
+    expect(screen.getByDisplayValue("DYMO LabelWriter 450")).toBeInTheDocument();
+  });
 });
 
 describe("SettingsBar power toggle visibility", () => {

--- a/client/src/components/SettingsBar.tsx
+++ b/client/src/components/SettingsBar.tsx
@@ -34,9 +34,8 @@ export function SettingsBar() {
   const showPrinterSelector = availablePrinters.length > 1;
 
   // Hide the USB power toggle when a virtual printer is selected —
-  // virtual printers don't have a USB port to power off. When
-  // Auto-select is active or a real USB printer is selected, the
-  // toggle stays visible (and itself hides if the server can't
+  // virtual printers don't have a USB port to power off. For a real USB
+  // printer the toggle stays visible (and itself hides if the server can't
   // resolve a controllable port).
   const selectedPrinter = settings.printerId
     ? availablePrinters.find((p) => p.id === settings.printerId)
@@ -55,11 +54,8 @@ export function SettingsBar() {
             <select
               className="input w-48"
               value={settings.printerId || ""}
-              onChange={(e) =>
-                update({ printerId: e.target.value || undefined })
-              }
+              onChange={(e) => update({ printerId: e.target.value })}
             >
-              <option value="">Auto-select</option>
               {availablePrinters.map((p) => (
                 <option key={p.id} value={p.id}>
                   {p.name}

--- a/client/src/components/SettingsBar.tsx
+++ b/client/src/components/SettingsBar.tsx
@@ -33,13 +33,22 @@ export function SettingsBar() {
   // - Support printer-specific preset configurations
   const showPrinterSelector = availablePrinters.length > 1;
 
+  // The selection shown in the dropdown. Fall back to the first printer
+  // when the stored selection is missing or stale (e.g. transiently after
+  // importing a label with no printerId) so the controlled <select> always
+  // matches a rendered option rather than going blank with no value.
+  const effectivePrinterId =
+    settings.printerId &&
+    availablePrinters.some((p) => p.id === settings.printerId)
+      ? settings.printerId
+      : availablePrinters[0]?.id;
+
   // Hide the USB power toggle when a virtual printer is selected —
   // virtual printers don't have a USB port to power off. For a real USB
   // printer the toggle stays visible (and itself hides if the server can't
   // resolve a controllable port).
-  const selectedPrinter = settings.printerId
-    ? availablePrinters.find((p) => p.id === settings.printerId)
-    : null;
+  const selectedPrinter =
+    availablePrinters.find((p) => p.id === effectivePrinterId) ?? null;
   const selectedIsVirtual = selectedPrinter?.vendorProductId === "virtual";
 
   return (
@@ -53,7 +62,7 @@ export function SettingsBar() {
           <Field label="Printer">
             <select
               className="input w-48"
-              value={settings.printerId || ""}
+              value={effectivePrinterId ?? ""}
               onChange={(e) => update({ printerId: e.target.value })}
             >
               {availablePrinters.map((p) => (

--- a/client/src/state/useLabelStore.test.ts
+++ b/client/src/state/useLabelStore.test.ts
@@ -132,6 +132,43 @@ describe("Printers", () => {
     useLabelStore.getState().setAvailablePrinters(printers);
     expect(useLabelStore.getState().availablePrinters).toEqual(printers);
   });
+
+  it("defaults the selection to the first printer when none is chosen", () => {
+    useLabelStore.getState().setAvailablePrinters([
+      { id: "usb:1", name: "A", vendorProductId: "0922:1002" },
+      { id: "virtual:b", name: "B", vendorProductId: "virtual" },
+    ]);
+    expect(useLabelStore.getState().settings.printerId).toBe("usb:1");
+  });
+
+  it("keeps the current selection when it is still present", () => {
+    useLabelStore.setState({
+      settings: { ...useLabelStore.getState().settings, printerId: "virtual:b" },
+    });
+    useLabelStore.getState().setAvailablePrinters([
+      { id: "usb:1", name: "A", vendorProductId: "0922:1002" },
+      { id: "virtual:b", name: "B", vendorProductId: "virtual" },
+    ]);
+    expect(useLabelStore.getState().settings.printerId).toBe("virtual:b");
+  });
+
+  it("re-selects the first printer when the selected one vanishes", () => {
+    useLabelStore.setState({
+      settings: { ...useLabelStore.getState().settings, printerId: "virtual:b" },
+    });
+    useLabelStore.getState().setAvailablePrinters([
+      { id: "usb:1", name: "A", vendorProductId: "0922:1002" },
+    ]);
+    expect(useLabelStore.getState().settings.printerId).toBe("usb:1");
+  });
+
+  it("clears the selection when no printers are present", () => {
+    useLabelStore.setState({
+      settings: { ...useLabelStore.getState().settings, printerId: "usb:1" },
+    });
+    useLabelStore.getState().setAvailablePrinters([]);
+    expect(useLabelStore.getState().settings.printerId).toBeUndefined();
+  });
 });
 
 describe("Load", () => {

--- a/client/src/state/useLabelStore.ts
+++ b/client/src/state/useLabelStore.ts
@@ -222,7 +222,21 @@ export const useLabelStore = create<LabelStore>((set) => ({
   updateSettings: (patch) =>
     set((s) => ({ settings: { ...s.settings, ...patch } })),
 
-  setAvailablePrinters: (printers) => set({ availablePrinters: printers }),
+  setAvailablePrinters: (printers) =>
+    set((s) => {
+      // Default the selection to a concrete printer — the first in the list,
+      // which is the first real USB printer when one is present (virtual
+      // printers are listed after). This way a selected printer (and, with
+      // per-printer settings, its saved tape/colors) is active on load
+      // instead of an "Auto-select" placeholder. Keep the current selection
+      // if it's still connected; otherwise fall back to the first printer
+      // (or undefined when none are connected).
+      const stillPresent =
+        s.settings.printerId != null &&
+        printers.some((p) => p.id === s.settings.printerId);
+      const printerId = stillPresent ? s.settings.printerId : printers[0]?.id;
+      return { availablePrinters: printers, settings: { ...s.settings, printerId } };
+    }),
 
   updateBatch: (patch) =>
     set((s) => ({ batch: { ...s.batch, ...patch } })),

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -65,10 +65,9 @@ When batch mode is active and a row is selected, `LabelPreview` substitutes vari
 
 The app fetches available printers on load via `GET /api/printers`. If multiple printers are detected, a dropdown selector appears in the Settings panel with:
 - List of all printers (real USB + virtual printers)
-- "Auto-select" option (default)
 - Refresh button to re-scan USB devices
 
-The selected `printerId` is stored in `settings` and sent with print requests.
+The selection defaults to the first printer in the list (the first real USB printer when one is present; virtual printers are listed after), set in `setAvailablePrinters` — which also re-selects the first printer if the previously-selected one is no longer connected. The selected `printerId` is stored in `settings` and sent with print requests. (The server still accepts no `printerId` and auto-selects the first available printer; the UI just always sends a concrete one.)
 
 ### Batch Print
 


### PR DESCRIPTION
Stacked under #39 (per-printer settings); **no version bump** — ships in the single v1.8.0 that #39 cuts. Merges **before** #39, which builds on it.

## Why

The printer dropdown defaulted to an **"Auto-select"** entry — meaning no concrete printer was chosen and the server picked one only at print time. With per-printer settings (#39), that's backwards: on load you'd see app defaults (12 mm black/white) and only see a printer's saved tape/colors after manually picking it. (Found while testing #39 on the Pi.)

## What

- **Default the selection to a concrete printer** in `setAvailablePrinters`: the first printer in the list — which is the first real USB printer when present (virtual printers are listed after). So a real printer is selected on load, and (once #39 lands) its saved settings apply immediately.
- **Re-select the first printer if the chosen one vanishes** (unplugged), so the selection is never stale.
- **Remove the "Auto-select" dropdown entry.**
- The server still accepts no `printer_id` and auto-selects the first available printer — that fallback is unchanged; the UI just always sends a concrete printer now.

## Tests

Store: defaults to first printer, keeps a still-present selection, re-selects on vanish, clears when no printers. SettingsBar: lists printers without Auto-select, defaults to first, selecting updates the store. Frontend suite green (59); ARCHITECTURE.md updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)