### PR TITLE
refactor: extract shared state_store; route usb_power through it

### DIFF
--- a/server/state_store.py
+++ b/server/state_store.py
@@ -50,7 +50,7 @@ def read_all(path: Path | None = None) -> dict:
     if path is None:
         path = STATE_FILE
     try:
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError:
         return {}
     except (OSError, json.JSONDecodeError, UnicodeDecodeError) as e:
@@ -83,7 +83,7 @@ def update(mutator: Callable[[dict], None], path: Path | None = None) -> dict:
         try:
             path.parent.mkdir(parents=True, exist_ok=True)
             tmp = path.with_suffix(path.suffix + ".tmp")
-            tmp.write_text(json.dumps(data))
+            tmp.write_text(json.dumps(data), encoding="utf-8")
             tmp.replace(path)
         except (OSError, TypeError, ValueError) as e:
             logger.warning("Could not write state file %s: %s", path, e)

--- a/server/state_store.py
+++ b/server/state_store.py
@@ -1,0 +1,90 @@
+"""Shared owner of the on-disk JSON state file (LABELLE_STATE_FILE).
+
+Several features persist a little long-lived state across container
+restarts — the USB power feature caches the printer's (hub, port), and
+per-printer label settings live here too. They all share one
+file so the standard deployment needs only the single `/app/output`
+volume that's already mounted.
+
+Sharing one file means a writer touching its own slice must not drop
+another feature's slice. So every write is a read-modify-write of the
+whole document under a process-wide lock, and `update()` hands the
+mutator the full dict to edit in place. Writes are atomic-on-POSIX
+(serialize to a sibling `.tmp`, then `os.replace`), so a crash or a
+concurrent writer leaves the file fully old or fully new, never torn.
+
+Best-effort by design: a write failure (read-only fs, missing mount,
+permissions) only loses cross-restart memory, it never breaks runtime.
+"""
+
+import json
+import logging
+import os
+import threading
+from pathlib import Path
+from typing import Callable
+
+logger = logging.getLogger(__name__)
+
+# Default lives inside the Docker output mount, already a persistent
+# volume in the standard deployment — avoids requiring a new mount just
+# for this state. Tests pass an explicit path.
+STATE_FILE = Path(
+    os.environ.get("LABELLE_STATE_FILE", "/app/output/.labelle/state.json")
+)
+
+# Serializes read-modify-write across all callers. waitress serves on
+# multiple threads, and two features writing different slices of the same
+# file would otherwise interleave their read/write and lose one update.
+_lock = threading.Lock()
+
+
+def read_all(path: Path | None = None) -> dict:
+    """Return the whole state document as a dict; {} if absent/corrupt.
+
+    A missing file is the normal first-run state. A corrupt or
+    wrong-shaped file is logged and treated as empty rather than
+    crashing callers — the worst case is that prior state is forgotten
+    (and overwritten cleanly on the next write).
+    """
+    if path is None:
+        path = STATE_FILE
+    try:
+        data = json.loads(path.read_text())
+    except FileNotFoundError:
+        return {}
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError) as e:
+        # UnicodeDecodeError (non-UTF8 bytes) is a ValueError, not an
+        # OSError — catch it explicitly so a corrupt file is treated as
+        # empty rather than crashing the caller.
+        logger.warning("Could not read state file %s: %s", path, e)
+        return {}
+    if isinstance(data, dict):
+        return data
+    logger.warning("Ignoring state file %s: top level is not an object", path)
+    return {}
+
+
+def update(mutator: Callable[[dict], None], path: Path | None = None) -> dict:
+    """Atomically read-modify-write the state file under the shared lock.
+
+    `mutator` receives the full document and edits it in place. Returns
+    the resulting document. Failures are swallowed (best-effort) — both
+    I/O errors and JSON serialization errors (a non-serializable value
+    written by a feature) — so persisting state never crashes the caller's
+    actual operation. The in-memory result is still returned so callers
+    see their change even when the write didn't land.
+    """
+    if path is None:
+        path = STATE_FILE
+    with _lock:
+        data = read_all(path)
+        mutator(data)
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = path.with_suffix(path.suffix + ".tmp")
+            tmp.write_text(json.dumps(data))
+            tmp.replace(path)
+        except (OSError, TypeError, ValueError) as e:
+            logger.warning("Could not write state file %s: %s", path, e)
+        return data

--- a/server/tests/test_smoke.py
+++ b/server/tests/test_smoke.py
@@ -16,6 +16,7 @@ SERVER_MODULES = [
     "label_builder",
     "power_save",
     "printer_service",
+    "state_store",
     "usb_power",
     "virtual_printer",
 ]
@@ -56,6 +57,31 @@ class TestModuleListSync:
         assert not stale, (
             f"SERVER_MODULES lists modules that no longer exist: {stale}. "
             "Remove them from the list."
+        )
+
+
+class TestStateFileOwnership:
+    """state_store.py is the single owner of the on-disk state file."""
+
+    def test_only_state_store_references_the_state_file(self):
+        """Every other feature must persist via state_store.read_all/update
+        so writes stay atomic and non-clobbering. Reaching for
+        LABELLE_STATE_FILE elsewhere is how the pre-refactor usb_power saver
+        introduced full-file overwrites — guard against reintroducing it.
+
+        Catches the realistic regression (a new feature grabbing the env
+        var); a hand-hardcoded path would slip through, which is an
+        acceptable trade for a zero-false-positive check.
+        """
+        server_dir = Path(__file__).resolve().parent.parent
+        offenders = [
+            f.name
+            for f in server_dir.glob("*.py")
+            if f.name != "state_store.py" and "LABELLE_STATE_FILE" in f.read_text()
+        ]
+        assert not offenders, (
+            f"{offenders} reference LABELLE_STATE_FILE directly; "
+            "go through state_store.read_all/update instead."
         )
 
 

--- a/server/tests/test_state_store.py
+++ b/server/tests/test_state_store.py
@@ -1,0 +1,102 @@
+"""Tests for the shared JSON state store backing LABELLE_STATE_FILE.
+
+state_store is the single owner of the on-disk state file. Both the USB
+power feature (hub/port cache) and per-printer settings persistence write
+through it, so its read-modify-write must preserve keys it doesn't know
+about and be safe under concurrent callers.
+"""
+
+import json
+import threading
+
+import state_store
+
+
+class TestReadAll:
+    def test_returns_empty_dict_when_file_missing(self, tmp_path):
+        assert state_store.read_all(tmp_path / "absent.json") == {}
+
+    def test_returns_parsed_dict_when_valid(self, tmp_path):
+        p = tmp_path / "state.json"
+        p.write_text(json.dumps({"hub": "1-1", "port": 3}))
+        assert state_store.read_all(p) == {"hub": "1-1", "port": 3}
+
+    def test_returns_empty_dict_when_corrupt(self, tmp_path):
+        p = tmp_path / "state.json"
+        p.write_text("{not json")
+        assert state_store.read_all(p) == {}
+
+    def test_returns_empty_dict_when_top_level_not_object(self, tmp_path):
+        p = tmp_path / "state.json"
+        p.write_text(json.dumps([1, 2, 3]))
+        assert state_store.read_all(p) == {}
+
+    def test_returns_empty_dict_on_non_utf8_bytes(self, tmp_path):
+        # Non-UTF8 bytes raise UnicodeDecodeError (a ValueError, not OSError).
+        p = tmp_path / "state.json"
+        p.write_bytes(b"\xff\xfe\x00garbage")
+        assert state_store.read_all(p) == {}
+
+
+class TestUpdate:
+    def test_persists_mutation(self, tmp_path):
+        p = tmp_path / "state.json"
+        state_store.update(lambda d: d.update(hub="2-4", port=7), p)
+        assert state_store.read_all(p) == {"hub": "2-4", "port": 7}
+
+    def test_preserves_unrelated_keys(self, tmp_path):
+        """A writer touching one key must not drop another writer's keys."""
+        p = tmp_path / "state.json"
+        state_store.update(lambda d: d.update(hub="1-1", port=3), p)
+        state_store.update(
+            lambda d: d.setdefault("printers", {}).__setitem__("p1", {"tapeSizeMm": 12}),
+            p,
+        )
+        data = state_store.read_all(p)
+        assert data["hub"] == "1-1"
+        assert data["port"] == 3
+        assert data["printers"]["p1"] == {"tapeSizeMm": 12}
+
+    def test_creates_parent_dirs(self, tmp_path):
+        p = tmp_path / "nested" / "dir" / "state.json"
+        state_store.update(lambda d: d.update(hub="1-1", port=3), p)
+        assert p.exists()
+
+    def test_swallows_write_errors(self, tmp_path):
+        # Parent is a file, so mkdir/replace fail; update must not raise.
+        blocker = tmp_path / "blocker"
+        blocker.write_text("x")
+        bad_path = blocker / "state.json"
+        state_store.update(lambda d: d.update(hub="1-1", port=3), bad_path)
+
+    def test_swallows_serialization_errors(self, tmp_path):
+        # A non-JSON-serializable value must not crash the caller, and must
+        # leave any prior on-disk state intact (the bad write never lands).
+        p = tmp_path / "state.json"
+        state_store.update(lambda d: d.update(hub="1-1", port=3), p)
+        state_store.update(lambda d: d.update(bad={1, 2, 3}), p)  # set → TypeError
+        assert state_store.read_all(p) == {"hub": "1-1", "port": 3}
+
+    def test_returns_resulting_data(self, tmp_path):
+        p = tmp_path / "state.json"
+        result = state_store.update(lambda d: d.update(hub="1-1", port=3), p)
+        assert result == {"hub": "1-1", "port": 3}
+
+    def test_concurrent_updates_do_not_lose_writes(self, tmp_path):
+        """Read-modify-write under the lock must not drop interleaved writes."""
+        p = tmp_path / "state.json"
+        state_store.update(lambda d: d.setdefault("printers", {}), p)
+
+        def writer(key):
+            state_store.update(
+                lambda d: d["printers"].__setitem__(key, {"tapeSizeMm": 12}), p
+            )
+
+        threads = [threading.Thread(target=writer, args=(f"p{i}",)) for i in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        printers = state_store.read_all(p)["printers"]
+        assert set(printers) == {f"p{i}" for i in range(20)}

--- a/server/tests/test_state_store.py
+++ b/server/tests/test_state_store.py
@@ -37,6 +37,14 @@ class TestReadAll:
         p.write_bytes(b"\xff\xfe\x00garbage")
         assert state_store.read_all(p) == {}
 
+    def test_non_ascii_value_round_trips_as_utf8(self, tmp_path):
+        # The file is written and read as UTF-8 explicitly (not the process
+        # locale), so non-ASCII values survive regardless of environment.
+        p = tmp_path / "state.json"
+        state_store.update(lambda d: d.update(printers={"virtual:Büro": {}}), p)
+        assert p.read_text(encoding="utf-8")  # readable as UTF-8
+        assert state_store.read_all(p)["printers"] == {"virtual:Büro": {}}
+
 
 class TestUpdate:
     def test_persists_mutation(self, tmp_path):

--- a/server/tests/test_usb_power.py
+++ b/server/tests/test_usb_power.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
+import state_store
 import usb_power
 
 
@@ -204,6 +205,22 @@ class TestStatePersistence:
         p.write_text('{"hub": "1-1", "port": "3"}')
         assert usb_power._load_state(p) is None
 
+    def test_load_state_warns_on_invalid_shape(self, tmp_path, caplog):
+        p = tmp_path / "state.json"
+        p.write_text('{"hub": "1-1", "port": "3"}')
+        with caplog.at_level("WARNING"):
+            assert usb_power._load_state(p) is None
+        assert any("unexpected shape" in r.message for r in caplog.records)
+
+    def test_load_state_quiet_when_no_saved_port(self, tmp_path, caplog):
+        # A file with other features' keys but no hub/port is the normal
+        # case — must not warn.
+        p = tmp_path / "state.json"
+        p.write_text('{"printers": {"a": {"tapeSizeMm": 12}}}')
+        with caplog.at_level("WARNING"):
+            assert usb_power._load_state(p) is None
+        assert not any("unexpected shape" in r.message for r in caplog.records)
+
     def test_save_state_writes_round_trippable_json(self, tmp_path):
         p = tmp_path / "state.json"
         usb_power._save_state("2-4", 7, p)
@@ -226,21 +243,21 @@ class TestStatePersistence:
         self, mock_run, tmp_path, monkeypatch
     ):
         state_file = tmp_path / "state.json"
-        monkeypatch.setattr(usb_power, "_STATE_FILE", state_file)
+        monkeypatch.setattr(state_store, "STATE_FILE", state_file)
         usb_power._last_known_port = None
 
         mock_run.return_value = _result(UHUBCTL_DEFAULT_OUTPUT)
         usb_power.find_or_recall_printer_port()
 
         # Read it back through `_load_state()` with no arg so it
-        # resolves the same monkeypatched `_STATE_FILE`.
+        # resolves the same monkeypatched default state file.
         assert usb_power._load_state() == ("1-1", 3)
 
     def test_find_or_recall_does_not_rewrite_unchanged_value(
         self, mock_run, tmp_path, monkeypatch
     ):
         state_file = tmp_path / "state.json"
-        monkeypatch.setattr(usb_power, "_STATE_FILE", state_file)
+        monkeypatch.setattr(state_store, "STATE_FILE", state_file)
         usb_power._last_known_port = ("1-1", 3)
 
         mock_run.return_value = _result(UHUBCTL_DEFAULT_OUTPUT)

--- a/server/usb_power.py
+++ b/server/usb_power.py
@@ -173,8 +173,9 @@ def _load_state(path: Path | None = None) -> tuple[str, int] | None:
     if isinstance(hub, str) and isinstance(port, int):
         return hub, port
     # Quiet on the normal "no saved port yet" case, but warn if the keys
-    # are present with the wrong types — that's a corrupt state file worth
-    # surfacing (state_store.read_all only logs missing/corrupt-JSON files).
+    # are present with the wrong types — a wrong hub/port shape that
+    # state_store.read_all doesn't surface (it logs unreadable/non-object
+    # files, but a valid object with bad hub/port types reads back fine).
     if hub is not None or port is not None:
         logger.warning(
             "Ignoring saved printer port: unexpected shape hub=%r port=%r", hub, port

--- a/server/usb_power.py
+++ b/server/usb_power.py
@@ -8,7 +8,6 @@ support per-port power switching (ppps) — confirmed for the 2109:3431 USB
 2.0 hub on hector.
 """
 
-import json
 import logging
 import os
 import re
@@ -16,6 +15,8 @@ import subprocess
 from pathlib import Path
 
 import usb.backend.libusb1
+
+import state_store
 
 logger = logging.getLogger(__name__)
 
@@ -156,57 +157,38 @@ def power_off(hub: str, port: int) -> None:
     # power/status`) rather than libusb-based device enumeration.
 
 
-# Path where `_last_known_port` is persisted across container restarts.
-# Default lives inside the Docker output mount, which is already a
-# persistent volume in the standard deployment — avoids requiring a
-# new volume mount just for this state. Tests pass an explicit path.
-_STATE_FILE = Path(
-    os.environ.get("LABELLE_STATE_FILE", "/app/output/.labelle/state.json")
-)
+# The (hub, port) cache is persisted across container restarts as the
+# top-level "hub"/"port" keys of the shared state file. We go through
+# state_store (rather than writing the file directly) so that saving the
+# port doesn't clobber the per-printer settings that share the file —
+# state_store does a read-modify-write of the whole document under a
+# shared lock. See server/state_store.py and printer_settings.py.
 
 
 def _load_state(path: Path | None = None) -> tuple[str, int] | None:
     """Read a previously-saved (hub, port) from disk, or None if absent/invalid."""
-    if path is None:
-        path = _STATE_FILE
-    try:
-        data = json.loads(path.read_text())
-    except FileNotFoundError:
-        return None
-    except (OSError, json.JSONDecodeError) as e:
-        logger.warning("Could not load printer port state from %s: %s", path, e)
-        return None
+    data = state_store.read_all(path)
     hub = data.get("hub")
     port = data.get("port")
     if isinstance(hub, str) and isinstance(port, int):
         return hub, port
-    logger.warning(
-        "Ignoring printer port state from %s: unexpected shape %r", path, data
-    )
+    # Quiet on the normal "no saved port yet" case, but warn if the keys
+    # are present with the wrong types — that's a corrupt state file worth
+    # surfacing (state_store.read_all only logs missing/corrupt-JSON files).
+    if hub is not None or port is not None:
+        logger.warning(
+            "Ignoring saved printer port: unexpected shape hub=%r port=%r", hub, port
+        )
     return None
 
 
 def _save_state(hub: str, port: int, path: Path | None = None) -> None:
     """Persist (hub, port) so a container restart can recover the cache.
 
-    Best-effort: a write failure (read-only fs, missing volume mount,
-    permissions) only loses cross-restart memory, never breaks runtime.
-
-    Writes are atomic-on-POSIX: serialize to a sibling `.tmp` file
-    first, then `os.replace()` over the target. A process interrupted
-    mid-write (or another thread writing concurrently) leaves the
-    target either fully old or fully new, never a torn JSON that
-    `_load_state` would have to discard.
+    Best-effort and atomic — see state_store.update. Merges into the
+    shared document so sibling keys (e.g. per-printer settings) survive.
     """
-    if path is None:
-        path = _STATE_FILE
-    try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_suffix(path.suffix + ".tmp")
-        tmp.write_text(json.dumps({"hub": hub, "port": port}))
-        tmp.replace(path)
-    except OSError as e:
-        logger.warning("Could not save printer port state to %s: %s", path, e)
+    state_store.update(lambda d: d.update(hub=hub, port=port), path)
 
 
 # Module-global, intentionally unlocked. waitress serves requests on


### PR DESCRIPTION
Infrastructure split out of #39 so that PR stays focused on the feature. **No version bump** — ships in the single v1.8.0 with #39, which builds on this.

## Why

`usb_power` persisted its `(hub, port)` cache by serializing just those two keys and replacing the whole state file. That's an **atomic** write but a **full-file overwrite** — fine while `usb_power` is the only writer, but it would clobber any other feature's slice of the same file.

## What

`server/state_store.py` — the single owner of `LABELLE_STATE_FILE`:
- **Atomic read-modify-write** of the whole document under a process-wide lock (so independent features each persist their slice without clobbering).
- **Best-effort**: swallows both I/O *and* JSON-serialization errors (a bad write loses cross-restart memory, never crashes the request).
- Tolerant of a missing / corrupt / non-UTF8 file (treated as empty).

`usb_power` now routes its load/save through it — same on-disk shape (`hub`/`port` at top level), same `path` argument, behavior-preserving (its tests still pass). It also now warns on a *present-but-invalid* hub/port shape.

A smoke test guards the invariant: **only `state_store.py` may reference `LABELLE_STATE_FILE`**, so no feature reintroduces direct (clobbering) access.

## Why now

This is the shared-file foundation the upcoming per-printer settings (#39) builds on. Landing it separately keeps #39 to just the feature.

## Tests

New `test_state_store.py` (atomic RMW, key preservation, concurrency, corrupt/non-UTF8/serialization handling); `test_usb_power` updated for the delegation + invalid-shape warning; smoke ownership guard. Full backend suite green (252).

🤖 Generated with [Claude Code](https://claude.com/claude-code)