### PR TITLE
fix: recover from stale libusb context in list_printers (v1.8.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labelle-web",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "private": true,
   "description": "Web interface for labelle DYMO label printers",
   "scripts": {

--- a/server/printer_service.py
+++ b/server/printer_service.py
@@ -6,17 +6,20 @@ from PIL import Image
 from labelle.lib.devices.device_manager import DeviceManager, DeviceManagerNoDevices
 from labelle.lib.devices.dymo_labeler import DymoLabeler
 
+import usb_power
 from config import get_virtual_printers
 from label_builder import render_payload, render_preview
 from virtual_printer import VirtualPrinter
 
 logger = logging.getLogger(__name__)
 
-# Note: libusb cache invalidation lives in `usb_power.power_on()`, not
-# here. Scans rely on the cache being already-fresh from the last power
-# transition. See `usb_power._invalidate_libusb_cache` for the rationale
-# (resetting libusb in the read path triggers kernel hub auto-resume
-# which re-energizes off ports).
+# Libusb cache invalidation is normally driven by `usb_power.power_on()`, so
+# scans rely on the cache being already-fresh from the last power transition.
+# We refresh it from this read path in exactly one case — recovering a stale
+# context after a re-enumeration (see `_list_real_printers`) — and only when
+# uhubctl confirms the device is physically present. That gate is what keeps
+# us from triggering the kernel hub auto-resume that would re-energize a
+# deliberately powered-off port. See `usb_power.invalidate_libusb_cache`.
 
 
 def _printer_id(dev) -> str:
@@ -57,42 +60,83 @@ def _fallback_to_virtual(widgets: list[dict], settings: dict, upload_dir: str) -
     vp.save(preview_bitmap, widgets, settings)
 
 
+def _scan_real_printers() -> list[dict]:
+    """Scan USB once and return real DYMO printers as dicts.
+
+    Raises DeviceManagerNoDevices when the scan finds nothing.
+    """
+    device_manager = DeviceManager()
+    device_manager.scan()
+
+    printers: list[dict] = []
+    for dev in device_manager.devices:
+        parts = []
+        if dev.manufacturer:
+            parts.append(dev.manufacturer)
+        if dev.product:
+            parts.append(dev.product)
+        if dev.serial_number:
+            parts.append(f"(S/N: {dev.serial_number})")
+
+        name = " ".join(parts) if parts else dev.usb_id
+
+        printers.append({
+            "id": _printer_id(dev),
+            "name": name,
+            "vendorProductId": dev.vendor_product_id,
+            "serialNumber": dev.serial_number,
+        })
+    return printers
+
+
+def _list_real_printers() -> list[dict]:
+    """Real USB DYMO printers, with stale-libusb-context recovery.
+
+    In a long-lived process pyusb caches its libusb context. If the printer
+    re-enumerates to a new bus address (replug, or our own USB power-cycle)
+    after that context is built, the scan keeps coming back empty even though
+    the device is physically attached. When that happens — empty scan but
+    uhubctl still sees the DYMO — drop the cached context and rescan once so
+    the device reappears without a process restart.
+
+    Never raises; returns [] on any failure.
+    """
+    try:
+        return _scan_real_printers()
+    except DeviceManagerNoDevices:
+        pass  # genuinely absent, or a stale context — disambiguate below
+    except Exception:
+        traceback.print_exc()
+        return []
+
+    # The scan found nothing. Only refresh the cache when uhubctl confirms the
+    # DYMO is still physically attached: that both targets the stale-context
+    # case and guarantees we never resume a deliberately powered-off port
+    # (where uhubctl sees no device, so this gate is False).
+    if usb_power.printer_attached():
+        logger.info(
+            "USB scan empty but uhubctl still sees the DYMO; refreshing the "
+            "stale libusb context and rescanning."
+        )
+        usb_power.invalidate_libusb_cache()
+        try:
+            return _scan_real_printers()
+        except Exception:
+            pass  # recovery didn't help; fall through to the empty result
+
+    # Expected state when no DYMO is plugged in (e.g. local dev or a host with
+    # only virtual printers). Surface as INFO without a traceback so the
+    # console stays clean across plug/unplug cycles.
+    logger.info("No USB DYMO printers detected.")
+    return []
+
+
 def list_printers() -> list[dict]:
     """List all available printers: real DYMO printers via USB and configured virtual printers.
 
     Never raises; returns partial results on scan failure.
     """
-    printers: list[dict] = []
-
-    # Add real USB printers
-    try:
-        device_manager = DeviceManager()
-        device_manager.scan()
-
-        for dev in device_manager.devices:
-            parts = []
-            if dev.manufacturer:
-                parts.append(dev.manufacturer)
-            if dev.product:
-                parts.append(dev.product)
-            if dev.serial_number:
-                parts.append(f"(S/N: {dev.serial_number})")
-
-            name = " ".join(parts) if parts else dev.usb_id
-
-            printers.append({
-                "id": _printer_id(dev),
-                "name": name,
-                "vendorProductId": dev.vendor_product_id,
-                "serialNumber": dev.serial_number,
-            })
-    except DeviceManagerNoDevices:
-        # Expected state when no DYMO is plugged in (e.g. local dev or a
-        # host with only virtual printers). Surface as INFO without a
-        # traceback so the console stays clean across plug/unplug cycles.
-        logger.info("No USB DYMO printers detected.")
-    except Exception:
-        traceback.print_exc()
+    printers: list[dict] = _list_real_printers()
 
     # Add virtual printers from configuration
     try:

--- a/server/tests/test_printer_service.py
+++ b/server/tests/test_printer_service.py
@@ -178,6 +178,101 @@ class TestListPrintersUsbScanFailure:
         assert len(info_msgs) == 1
 
 
+class TestStaleLibusbContextRecovery:
+    """A long-lived process caches its libusb context. If the printer
+    re-enumerates to a new bus address (replug, or our own USB power-cycle)
+    after that context is built, scans keep coming back empty even though the
+    device is physically attached. list_printers() must recover: when a scan
+    is empty BUT uhubctl still sees the DYMO, drop the cached context and
+    rescan once — without ever resuming a deliberately powered-off port."""
+
+    @patch("printer_service.usb_power")
+    @patch("printer_service.DeviceManager")
+    def test_recovers_when_printer_still_attached(
+        self, mock_dm_cls, mock_usb_power, no_virtual_printers_env
+    ):
+        from labelle.lib.devices.device_manager import DeviceManagerNoDevices
+
+        mock_dm = MagicMock()
+        # First scan: stale context sees nothing. After cache invalidation the
+        # second scan re-enumerates and finds the device.
+        mock_dm.scan.side_effect = [DeviceManagerNoDevices("none"), None]
+        mock_dm.devices = [_fake_device(serial="ABC123")]
+        mock_dm_cls.return_value = mock_dm
+        mock_usb_power.printer_attached.return_value = True
+
+        from printer_service import list_printers
+
+        result = list_printers()
+
+        mock_usb_power.invalidate_libusb_cache.assert_called_once()
+        assert [p["id"] for p in result] == ["serial:ABC123"]
+
+    @patch("printer_service.usb_power")
+    @patch("printer_service.DeviceManager")
+    def test_no_refresh_when_uhubctl_does_not_see_printer(
+        self, mock_dm_cls, mock_usb_power, no_virtual_printers_env
+    ):
+        """Powered-off / genuinely-absent: uhubctl sees no DYMO, so we must
+        NOT touch the libusb cache (a refresh would resume the hub and
+        re-energize a port the user deliberately powered off)."""
+        from labelle.lib.devices.device_manager import DeviceManagerNoDevices
+
+        mock_dm = MagicMock()
+        mock_dm.scan.side_effect = DeviceManagerNoDevices("none")
+        mock_dm_cls.return_value = mock_dm
+        mock_usb_power.printer_attached.return_value = False
+
+        from printer_service import list_printers
+
+        result = list_printers()
+
+        mock_usb_power.invalidate_libusb_cache.assert_not_called()
+        assert result == []
+
+    @patch("printer_service.usb_power")
+    @patch("printer_service.DeviceManager")
+    def test_no_uhubctl_probe_on_successful_first_scan(
+        self, mock_dm_cls, mock_usb_power, no_virtual_printers_env
+    ):
+        """The happy path must not consult uhubctl or refresh the cache."""
+        mock_dm = MagicMock()
+        mock_dm.devices = [_fake_device(serial="ABC123")]
+        mock_dm_cls.return_value = mock_dm
+
+        from printer_service import list_printers
+
+        result = list_printers()
+
+        mock_usb_power.printer_attached.assert_not_called()
+        mock_usb_power.invalidate_libusb_cache.assert_not_called()
+        assert [p["id"] for p in result] == ["serial:ABC123"]
+
+    @patch("printer_service.usb_power")
+    @patch("printer_service.DeviceManager")
+    def test_refresh_that_still_finds_nothing_returns_empty(
+        self, mock_dm_cls, mock_usb_power, no_virtual_printers_env
+    ):
+        """If the refresh+rescan still finds nothing, return gracefully
+        rather than raising."""
+        from labelle.lib.devices.device_manager import DeviceManagerNoDevices
+
+        mock_dm = MagicMock()
+        mock_dm.scan.side_effect = [
+            DeviceManagerNoDevices("none"),
+            DeviceManagerNoDevices("still none"),
+        ]
+        mock_dm_cls.return_value = mock_dm
+        mock_usb_power.printer_attached.return_value = True
+
+        from printer_service import list_printers
+
+        result = list_printers()
+
+        mock_usb_power.invalidate_libusb_cache.assert_called_once()
+        assert result == []
+
+
 class TestAutoSelectWithVirtualPrinters:
     @patch("printer_service.DeviceManager")
     def test_auto_select_falls_back_to_virtual_printer(

--- a/server/tests/test_usb_power.py
+++ b/server/tests/test_usb_power.py
@@ -70,6 +70,36 @@ class TestFindPrinterPort:
         assert usb_power.find_printer_port("0922:1002") is None
 
 
+class TestPrinterAttached:
+    """printer_attached() is the uhubctl-based presence gate for the
+    stale-libusb-context recovery in list_printers(). It must be a quiet,
+    best-effort probe: True only when uhubctl actually sees the DYMO, and
+    silent (no power-feature warning) on the read path when uhubctl is
+    absent."""
+
+    def setup_method(self):
+        usb_power._uhubctl_missing_logged = False
+
+    def test_true_when_uhubctl_sees_dymo(self, mock_run):
+        mock_run.return_value = _result(UHUBCTL_DEFAULT_OUTPUT)
+        with patch.object(usb_power.shutil, "which", return_value="/usr/sbin/uhubctl"):
+            assert usb_power.printer_attached() is True
+
+    def test_false_when_uhubctl_sees_no_dymo(self, mock_run):
+        mock_run.return_value = _result(UHUBCTL_DEFAULT_OUTPUT)
+        with patch.object(usb_power.shutil, "which", return_value="/usr/sbin/uhubctl"):
+            assert usb_power.printer_attached("dead:beef") is False
+
+    def test_quiet_and_false_when_uhubctl_missing(self, mock_run, caplog):
+        # The whole point of the review fix: a missing uhubctl on the read
+        # path must NOT run uhubctl or log the "uhubctl missing" warning.
+        with patch.object(usb_power.shutil, "which", return_value=None):
+            with caplog.at_level("WARNING", logger="usb_power"):
+                assert usb_power.printer_attached() is False
+        mock_run.assert_not_called()
+        assert not [r for r in caplog.records if "uhubctl" in r.message]
+
+
 class TestUhubctlMissing:
     """When uhubctl isn't installed (e.g. local dev outside Docker),
     subprocess.run raises FileNotFoundError. Surface that as a benign

--- a/server/usb_power.py
+++ b/server/usb_power.py
@@ -11,6 +11,7 @@ support per-port power switching (ppps) — confirmed for the 2109:3431 USB
 import logging
 import os
 import re
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -121,6 +122,13 @@ def printer_attached(vendor_product_id: str = DYMO_USB_ID) -> bool:
     never re-create the libusb context on a hunch, so we can't accidentally
     resume a hub and re-energize a deliberately powered-off port.
     """
+    # Short-circuit when uhubctl isn't installed: this read-path probe must
+    # stay quiet. Calling through to `_run` would emit the latched "uhubctl
+    # missing" WARNING aimed at the power-control paths, surfacing a
+    # power-feature warning on plain printer listing in setups that never use
+    # power features (e.g. virtual-printer-only dev).
+    if shutil.which(UHUBCTL_BIN) is None:
+        return False
     try:
         return find_printer_port(vendor_product_id) is not None
     except Exception:

--- a/server/usb_power.py
+++ b/server/usb_power.py
@@ -41,7 +41,7 @@ _PORT_LINE_RE = re.compile(r"\s+Port (\d+):\s+(\w+)(.*)")
 _uhubctl_missing_logged = False
 
 
-def _invalidate_libusb_cache() -> None:
+def invalidate_libusb_cache() -> None:
     """Drop pyusb's cached libusb context so the next scan re-enumerates.
 
     pyusb's `usb.backend.libusb1` caches a `_lib_object` at module level
@@ -106,6 +106,27 @@ def find_printer_port(vendor_product_id: str = DYMO_USB_ID) -> tuple[str, int] |
     return None
 
 
+def printer_attached(vendor_product_id: str = DYMO_USB_ID) -> bool:
+    """Best-effort: does uhubctl currently see the DYMO on a hub port?
+
+    Reads uhubctl's device listing, so it's independent of pyusb's libusb
+    context — it stays accurate even when that context has gone stale after a
+    device re-enumeration. Used as the gate for the stale-context recovery in
+    `printer_service.list_printers`: an empty libusb scan while this returns
+    True means the device is physically present but the cached context is
+    stale.
+
+    Best-effort by design: any failure (uhubctl missing or erroring) returns
+    False — "can't confirm". A False gate is the safe default; it means we
+    never re-create the libusb context on a hunch, so we can't accidentally
+    resume a hub and re-energize a deliberately powered-off port.
+    """
+    try:
+        return find_printer_port(vendor_product_id) is not None
+    except Exception:
+        return False
+
+
 def get_port_status(hub: str, port: int) -> dict:
     """Return {'powered': bool, 'connected': bool} for a specific hub port.
 
@@ -144,13 +165,13 @@ def power_on(hub: str, port: int) -> None:
     set_port_power(hub, port, on=True)
     # Device just (re-)appeared at a new bus address; drop libusb's
     # cached enumeration so the next scan sees the live state.
-    _invalidate_libusb_cache()
+    invalidate_libusb_cache()
 
 
 def power_off(hub: str, port: int) -> None:
     set_port_power(hub, port, on=False)
     # Deliberately NOT invalidating the libusb cache here — see
-    # `_invalidate_libusb_cache` docstring. A libusb re-init would
+    # `invalidate_libusb_cache` docstring. A libusb re-init would
     # trigger a hub auto-resume that re-energizes the port we just
     # turned off. Callers that need to read accurate USB topology
     # while a port is off should use uhubctl-based status (`/api/


### PR DESCRIPTION
## Problem

On a long-running deployment (observed on `label.hakhorst.eu` / hector), `/api/printers` returned `[]` even though the Dymo was plugged in and powered. With no printer detected, the client has no printer id to key against, so `effectivePrinterId()` returns `undefined`, `usePrinterSettings.persist()` no-ops, and **per-printer settings silently stop being saved**.

## Root cause

Not lost USB access — a **stale process-wide libusb context**. pyusb caches its libusb context at module level. When the Dymo re-enumerates to a new bus address (replug, or our own USB power-cycle), the cached context keeps returning an empty scan even though the device is physically attached. The codebase already knew about this (`usb_power.invalidate_libusb_cache`, called after `power_on()`), but `list_printers()` never invalidated — that asymmetry was the bug.

Confirmed on the box: a fresh libusb context inside the stuck container enumerated the printer instantly, while the 8h-old app process saw nothing. `uhubctl` (libusb-independent) showed `Port 3 … connect [0922:1002 …]` throughout.

## Fix

`list_printers()` now recovers from this state. On an empty scan, if `uhubctl` still sees the DYMO on a hub port, drop the cached libusb context and rescan once — so the printer reappears **without a process/container restart**.

The `uhubctl` gate is deliberate and addresses the existing comment's concern: re-creating the libusb context can trigger a kernel hub auto-resume that re-energizes a port. By only refreshing when `uhubctl` confirms a device is physically present, we never resume a **deliberately powered-off** port (no device on the bus → gate is False).

- promote `usb_power._invalidate_libusb_cache` → public `invalidate_libusb_cache`
- add `usb_power.printer_attached()` (uhubctl-based, best-effort presence check)
- refactor the USB scan into `_scan_real_printers()` + recovery-aware `_list_real_printers()`

## Testing

- 4 new regression tests (`TestStaleLibusbContextRecovery`): recovers when attached; no refresh when uhubctl sees nothing (respects power-off); no uhubctl probe on the happy path; graceful empty when recovery still finds nothing.
- Full backend suite: **283 passing**.
- Validated the gate would fire in the *current* stuck production state.

## Version

PATCH bump `1.8.0` → `1.8.1` (bug fix, no behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)