### PR TITLE
fix: self-heal stale libusb context in the print path (#48)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labelle-web",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "private": true,
   "description": "Web interface for labelle DYMO label printers",
   "scripts": {

--- a/server/printer_service.py
+++ b/server/printer_service.py
@@ -15,11 +15,12 @@ logger = logging.getLogger(__name__)
 
 # Libusb cache invalidation is normally driven by `usb_power.power_on()`, so
 # scans rely on the cache being already-fresh from the last power transition.
-# We refresh it from this read path in exactly one case — recovering a stale
-# context after a re-enumeration (see `_list_real_printers`) — and only when
-# uhubctl confirms the device is physically present. That gate is what keeps
-# us from triggering the kernel hub auto-resume that would re-energize a
-# deliberately powered-off port. See `usb_power.invalidate_libusb_cache`.
+# We also refresh it from this read path to recover a stale context after a
+# re-enumeration — both when listing (`_list_real_printers`) and when resolving
+# a print request (`_resolve_device`) — but only when uhubctl confirms the
+# device is physically present. That gate is what keeps us from triggering the
+# kernel hub auto-resume that would re-energize a deliberately powered-off
+# port. See `usb_power.invalidate_libusb_cache`.
 
 
 def _printer_id(dev) -> str:
@@ -154,6 +155,58 @@ def list_printers() -> list[dict]:
     return printers
 
 
+def _scan_and_select(printer_id: str | None):
+    """Scan USB once and resolve to a device, or None if it isn't found.
+
+    Returns None both when the scan finds nothing and when an explicit
+    printer_id matches no attached device, so the caller can decide whether to
+    attempt stale-context recovery before giving up. Mirrors the resolution
+    logic list_printers uses, but yields the live device object the print path
+    needs rather than a descriptor dict.
+    """
+    device_manager = DeviceManager()
+    try:
+        device_manager.scan()
+        if printer_id:
+            return next(
+                (dev for dev in device_manager.devices if _printer_id(dev) == printer_id),
+                None,
+            )
+        return device_manager.find_and_select_device()
+    except DeviceManagerNoDevices:
+        return None
+
+
+def _resolve_device(printer_id: str | None):
+    """Resolve a print request to a live device, with stale-libusb recovery.
+
+    Same recovery as `_list_real_printers`: if the first scan doesn't resolve
+    the device but uhubctl still sees the DYMO, the cached libusb context is
+    likely stale after a re-enumeration — drop it and rescan once. The
+    `printer_attached()` gate also guarantees we never resume a deliberately
+    powered-off port (uhubctl reports no device there, so the gate is False).
+
+    Raises on failure so callers keep their existing semantics: an unmatched
+    explicit printer_id raises ValueError (propagated to the API), while an
+    auto-select miss raises DeviceManagerNoDevices (translated to the virtual
+    fallback). See #48.
+    """
+    device = _scan_and_select(printer_id)
+    if device is None and usb_power.printer_attached():
+        logger.info(
+            "Print scan didn't find the target printer but uhubctl still sees "
+            "the DYMO; refreshing the stale libusb context and rescanning."
+        )
+        usb_power.invalidate_libusb_cache()
+        device = _scan_and_select(printer_id)
+
+    if device is None:
+        if printer_id:
+            raise ValueError(f"Printer not found: {printer_id}")
+        raise DeviceManagerNoDevices("No supported devices found")
+    return device
+
+
 def print_label(
     widgets: list[dict], settings: dict, upload_dir: str = "", printer_id: str | None = None
 ) -> None:
@@ -177,18 +230,8 @@ def print_label(
         return
 
     # Try real USB printer
-    device = None
     try:
-        device_manager = DeviceManager()
-        device_manager.scan()
-
-        if printer_id:
-            matching_devices = [dev for dev in device_manager.devices if _printer_id(dev) == printer_id]
-            if not matching_devices:
-                raise ValueError(f"Printer not found: {printer_id}")
-            device = matching_devices[0]
-        else:
-            device = device_manager.find_and_select_device()
+        device = _resolve_device(printer_id)
     except Exception:
         # If a specific printer was requested but not found, don't fall back
         if printer_id:
@@ -253,17 +296,8 @@ def print_bitmap(
         return
 
     # Try real USB printer
-    device = None
     try:
-        device_manager = DeviceManager()
-        device_manager.scan()
-        if printer_id:
-            matching = [d for d in device_manager.devices if _printer_id(d) == printer_id]
-            if not matching:
-                raise ValueError(f"Printer not found: {printer_id}")
-            device = matching[0]
-        else:
-            device = device_manager.find_and_select_device()
+        device = _resolve_device(printer_id)
     except Exception:
         if printer_id:
             raise

--- a/server/tests/test_printer_service.py
+++ b/server/tests/test_printer_service.py
@@ -273,6 +273,136 @@ class TestStaleLibusbContextRecovery:
         assert result == []
 
 
+class TestPrintStaleLibusbContextRecovery:
+    """The same stale-libusb-context failure that empties list_printers() also
+    breaks the *print* path: print_label / print_bitmap scan for the requested
+    device and, with a stale context, find nothing (or the wrong device) even
+    though the printer is physically attached. They must recover the same way
+    list_printers() does — refresh the cache and rescan once, gated on uhubctl
+    confirming the DYMO is still present. See #48."""
+
+    @patch("printer_service.usb_power")
+    @patch("printer_service.render_payload")
+    @patch("printer_service.DymoLabeler")
+    @patch("printer_service.DeviceManager")
+    def test_print_label_recovers_when_printer_still_attached(
+        self, mock_dm_cls, mock_labeler_cls, mock_render, mock_usb_power,
+        sample_widgets, sample_settings,
+    ):
+        from labelle.lib.devices.device_manager import DeviceManagerNoDevices
+
+        dev = _fake_device(serial="ABC123")
+        mock_dm = MagicMock()
+        # First scan: stale context sees nothing. After cache invalidation the
+        # second scan re-enumerates and the device reappears.
+        mock_dm.scan.side_effect = [DeviceManagerNoDevices("none"), None]
+        mock_dm.devices = [dev]
+        mock_dm_cls.return_value = mock_dm
+        mock_usb_power.printer_attached.return_value = True
+
+        from printer_service import print_label
+
+        print_label(sample_widgets, sample_settings, printer_id="serial:ABC123")
+
+        mock_usb_power.invalidate_libusb_cache.assert_called_once()
+        dev.setup.assert_called_once()
+        mock_labeler_cls.return_value.print.assert_called_once()
+
+    @patch("printer_service.usb_power")
+    @patch("printer_service.DeviceManager")
+    def test_print_label_no_refresh_when_uhubctl_does_not_see_printer(
+        self, mock_dm_cls, mock_usb_power, sample_widgets, sample_settings,
+    ):
+        """Powered-off / genuinely-absent: don't touch the libusb cache, and
+        surface the same "Printer not found" the caller already handles."""
+        from labelle.lib.devices.device_manager import DeviceManagerNoDevices
+
+        mock_dm = MagicMock()
+        mock_dm.scan.side_effect = DeviceManagerNoDevices("none")
+        mock_dm_cls.return_value = mock_dm
+        mock_usb_power.printer_attached.return_value = False
+
+        from printer_service import print_label
+
+        with pytest.raises(ValueError, match="Printer not found"):
+            print_label(sample_widgets, sample_settings, printer_id="serial:ABC123")
+
+        mock_usb_power.invalidate_libusb_cache.assert_not_called()
+
+    @patch("printer_service.usb_power")
+    @patch("printer_service.render_payload")
+    @patch("printer_service.DymoLabeler")
+    @patch("printer_service.DeviceManager")
+    def test_print_label_no_uhubctl_probe_on_successful_first_scan(
+        self, mock_dm_cls, mock_labeler_cls, mock_render, mock_usb_power,
+        sample_widgets, sample_settings,
+    ):
+        """The happy path must not consult uhubctl or refresh the cache."""
+        dev = _fake_device(serial="ABC123")
+        mock_dm = MagicMock()
+        mock_dm.devices = [dev]
+        mock_dm_cls.return_value = mock_dm
+
+        from printer_service import print_label
+
+        print_label(sample_widgets, sample_settings, printer_id="serial:ABC123")
+
+        mock_usb_power.printer_attached.assert_not_called()
+        mock_usb_power.invalidate_libusb_cache.assert_not_called()
+
+    @patch("printer_service.usb_power")
+    @patch("printer_service.DymoLabeler")
+    @patch("printer_service.DeviceManager")
+    def test_print_bitmap_recovers_when_printer_still_attached(
+        self, mock_dm_cls, mock_labeler_cls, mock_usb_power, sample_settings,
+    ):
+        """print_bitmap is the path that actually failed in the field (the
+        cut-mark print goes through it)."""
+        from PIL import Image
+        from labelle.lib.devices.device_manager import DeviceManagerNoDevices
+
+        dev = _fake_device(serial="ABC123")
+        mock_dm = MagicMock()
+        mock_dm.scan.side_effect = [DeviceManagerNoDevices("none"), None]
+        mock_dm.devices = [dev]
+        mock_dm_cls.return_value = mock_dm
+        mock_usb_power.printer_attached.return_value = True
+
+        from printer_service import print_bitmap
+
+        print_bitmap(Image.new("1", (8, 8)), sample_settings, printer_id="serial:ABC123")
+
+        mock_usb_power.invalidate_libusb_cache.assert_called_once()
+        dev.setup.assert_called_once()
+        mock_labeler_cls.return_value.print.assert_called_once()
+
+    @patch("printer_service.usb_power")
+    @patch("printer_service.render_payload")
+    @patch("printer_service.DymoLabeler")
+    @patch("printer_service.DeviceManager")
+    def test_auto_select_recovers_when_printer_still_attached(
+        self, mock_dm_cls, mock_labeler_cls, mock_render, mock_usb_power,
+        sample_widgets, sample_settings,
+    ):
+        """Auto-select (printer_id=None) resolves via find_and_select_device;
+        it too must recover from a stale context rather than wrongly falling
+        back to a virtual printer when the real one is attached."""
+        from labelle.lib.devices.device_manager import DeviceManagerNoDevices
+
+        dev = _fake_device(serial="ABC123")
+        mock_dm = MagicMock()
+        mock_dm.find_and_select_device.side_effect = [DeviceManagerNoDevices("none"), dev]
+        mock_dm_cls.return_value = mock_dm
+        mock_usb_power.printer_attached.return_value = True
+
+        from printer_service import print_label
+
+        print_label(sample_widgets, sample_settings, printer_id=None)
+
+        mock_usb_power.invalidate_libusb_cache.assert_called_once()
+        dev.setup.assert_called_once()
+
+
 class TestAutoSelectWithVirtualPrinters:
     @patch("printer_service.DeviceManager")
     def test_auto_select_falls_back_to_virtual_printer(


### PR DESCRIPTION
Closes #48.

## Problem

On a long-running deploy, printing fails with the printer "connection down" even though the Dymo is plugged in and powered. Captured live on hector 2026-06-26 (~19:45–20:00 CEST): a run of failed prints through `generate → _print_label_with_cut_mark → print_bitmap`, alternating

```
ValueError: Printer not found: serial:08383504012013
labelle.lib.devices.device_manager.DeviceManagerNoDevices: No supported devices found
```

The v1.8.1 self-heal (PR #46) recovers a stale libusb context **only on the listing path** (`list_printers`/`_list_real_printers`), so `/api/printers` heals but **printing does not**. The print path scanned with a raw context and had no recovery.

Root cause: pyusb caches its libusb context module-level. When the Dymo re-enumerates to a new bus address **while its port stays powered** (a bus glitch, a physical replug, an autosuspend/resume), the cached context keeps returning the stale/empty list. The one place that drops the cache — `usb_power.power_on()` — only runs on an off→on transition (`power_save.ensure_powered()` no-ops when already powered), so a re-enumeration-while-powered is never healed. None of the user-side recoveries help: `power_off()` deliberately never invalidates, a physical replug bypasses the app, a UI reload only polls. In the field it eventually healed only because the idle power-saver did an off→on cycle.

## Fix

Extract `_resolve_device()` + `_scan_and_select()` in `printer_service.py` and reuse them from both `print_label` and `print_bitmap`, applying the same recovery `_list_real_printers` already uses: on an unresolved scan, if `usb_power.printer_attached()` (uhubctl, libusb-independent) still sees the DYMO, drop the cached libusb context and rescan once. The `printer_attached()` gate guarantees we never resume a deliberately powered-off port (uhubctl reports no device there). Existing fallback semantics are preserved — an unmatched explicit `printer_id` still raises to the API; an auto-select miss still falls back to the first virtual printer. Also removes the duplicated scan/match logic from both entry points.

## Tests

5 new tests in `TestPrintStaleLibusbContextRecovery`: recovery when still attached (`print_label` + `print_bitmap` paths), the no-recovery gate when uhubctl sees nothing (so a powered-off port is left alone), the happy path doesn't probe uhubctl, and auto-select recovery. Full backend suite: **291 passed**.

## Version

PATCH bump **1.8.1 → 1.8.2** (bug fix, no behavior change on the happy path).

## Not in scope

The separate `font size must be greater than 0` preview crash seen in the same incident is tracked as #49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
