### PR TITLE
fix: catch parent DeviceManagerError in print-path scan recovery (follow-up to #50)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labelle-web",
-  "version": "1.8.2",
+  "version": "1.8.4",
   "private": true,
   "description": "Web interface for labelle DYMO label printers",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labelle-web",
-  "version": "1.8.4",
+  "version": "1.8.2",
   "private": true,
   "description": "Web interface for labelle DYMO label printers",
   "scripts": {

--- a/server/printer_service.py
+++ b/server/printer_service.py
@@ -3,7 +3,11 @@ import traceback
 
 from PIL import Image
 
-from labelle.lib.devices.device_manager import DeviceManager, DeviceManagerNoDevices
+from labelle.lib.devices.device_manager import (
+    DeviceManager,
+    DeviceManagerError,
+    DeviceManagerNoDevices,
+)
 from labelle.lib.devices.dymo_labeler import DymoLabeler
 
 import usb_power
@@ -163,6 +167,12 @@ def _scan_and_select(printer_id: str | None):
     attempt stale-context recovery before giving up. Mirrors the resolution
     logic list_printers uses, but yields the live device object the print path
     needs rather than a descriptor dict.
+
+    Catches the parent `DeviceManagerError`, not just `DeviceManagerNoDevices`:
+    an empty scan raises the subclass, but `find_and_select_device()` raises the
+    plain parent ("No matching devices found") when a scan finds devices yet
+    none are usable. Both mean "no device to print to" — collapse them to None so
+    the recovery gate and the caller's fallback see a uniform result.
     """
     device_manager = DeviceManager()
     try:
@@ -173,7 +183,7 @@ def _scan_and_select(printer_id: str | None):
                 None,
             )
         return device_manager.find_and_select_device()
-    except DeviceManagerNoDevices:
+    except DeviceManagerError:
         return None
 
 

--- a/server/tests/test_printer_service.py
+++ b/server/tests/test_printer_service.py
@@ -384,14 +384,18 @@ class TestPrintStaleLibusbContextRecovery:
         self, mock_dm_cls, mock_labeler_cls, mock_render, mock_usb_power,
         sample_widgets, sample_settings,
     ):
-        """Auto-select (printer_id=None) resolves via find_and_select_device;
-        it too must recover from a stale context rather than wrongly falling
-        back to a virtual printer when the real one is attached."""
+        """Auto-select (printer_id=None) must recover from a stale context
+        rather than wrongly falling back to a virtual printer when the real one
+        is attached. The real stale symptom is an empty libusb scan, i.e.
+        scan() raising DeviceManagerNoDevices — not find_and_select_device."""
         from labelle.lib.devices.device_manager import DeviceManagerNoDevices
 
         dev = _fake_device(serial="ABC123")
         mock_dm = MagicMock()
-        mock_dm.find_and_select_device.side_effect = [DeviceManagerNoDevices("none"), dev]
+        # First scan: stale context sees nothing. After cache invalidation the
+        # second scan re-enumerates and find_and_select_device returns the device.
+        mock_dm.scan.side_effect = [DeviceManagerNoDevices("none"), None]
+        mock_dm.find_and_select_device.return_value = dev
         mock_dm_cls.return_value = mock_dm
         mock_usb_power.printer_attached.return_value = True
 
@@ -401,6 +405,22 @@ class TestPrintStaleLibusbContextRecovery:
 
         mock_usb_power.invalidate_libusb_cache.assert_called_once()
         dev.setup.assert_called_once()
+
+    @patch("printer_service.DeviceManager")
+    def test_scan_and_select_handles_find_and_select_device_error(self, mock_dm_cls):
+        """find_and_select_device raises the parent DeviceManagerError (not the
+        NoDevices subclass) when a scan finds devices but none are usable.
+        _scan_and_select must treat that as "no device" (None), like an empty
+        scan — otherwise the exception escapes the recovery gate."""
+        from labelle.lib.devices.device_manager import DeviceManagerError
+
+        mock_dm = MagicMock()
+        mock_dm.find_and_select_device.side_effect = DeviceManagerError("No matching devices found")
+        mock_dm_cls.return_value = mock_dm
+
+        from printer_service import _scan_and_select
+
+        assert _scan_and_select(None) is None
 
 
 class TestAutoSelectWithVirtualPrinters:


### PR DESCRIPTION
Follow-up to #50 (merged), from the independent self-review pass.

## Problem

`_scan_and_select` (added in #50) caught only `DeviceManagerNoDevices`:

```python
except DeviceManagerNoDevices:
    return None
```

But `DeviceManager.find_and_select_device()` raises the **parent**
`DeviceManagerError` ("No matching devices found") — not the subclass — when a
scan finds devices yet none are usable. That exception escaped the helper,
bypassing the stale-context recovery gate in `_resolve_device` (it still hit the
outer `except Exception` in `print_label`/`print_bitmap`, so the API behaviour
was correct, but the auto-select recovery path was effectively dead for that
exception shape).

The auto-select recovery **test** also mocked the wrong type
(`find_and_select_device.side_effect = [DeviceManagerNoDevices, dev]`), so it
green-lit a path that wouldn't fire in production.

Severity: MINOR. The real-world stale-context symptom is an *empty* scan, which
raises `DeviceManagerNoDevices` (already caught) — that path works. This is
correctness hygiene + test fidelity.

## Fix

- Catch the parent `DeviceManagerError` in `_scan_and_select` (the subclass is
  covered too), so both "empty scan" and "devices present but none usable"
  collapse to `None` and flow through the same recovery gate + fallback.
- Rewrite the auto-select recovery test to drive the realistic empty-scan path
  (`scan.side_effect = [DeviceManagerNoDevices, None]`), and add a unit test
  asserting `_scan_and_select` returns `None` when `find_and_select_device`
  raises `DeviceManagerError`.

Substantive change is one line (`except DeviceManagerNoDevices` →
`except DeviceManagerError`). Server tests: 24 passed.

## Version / merge order

PATCH **1.8.4**, assuming this merges **after** the 1.8.3 from #51 + #52. If it
lands before them, rebase the version (two PRs at the same version means the
second merge won't trigger a release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
